### PR TITLE
Remove lazy evaluation of parsed multiline, group, and article responses

### DIFF
--- a/Usenet/Nntp/Builders/NntpArticleBuilder.cs
+++ b/Usenet/Nntp/Builders/NntpArticleBuilder.cs
@@ -21,23 +21,19 @@ public class NntpArticleBuilder
         NntpHeaders.Date, NntpHeaders.From, NntpHeaders.Subject, NntpHeaders.MessageId, NntpHeaders.Newsgroups
     };
 
-    private MultiValueDictionary<string, string> _headers;
-    private NntpGroupsBuilder _groupsBuilder;
-    private NntpMessageId _messageId;
+    private MultiValueDictionary<string, string> _headers = new();
+    private NntpGroupsBuilder _groupsBuilder = new();
+    private NntpMessageId _messageId = NntpMessageId.Empty;
     private string _from;
     private string _subject;
     private DateTimeOffset? _dateTime;
-    private IEnumerable<string> _body;
+    private List<string> _body = [];
 
     /// <summary>
     /// Creates a new instance of the <see cref="NntpArticleBuilder"/> class.
     /// </summary>
     public NntpArticleBuilder()
     {
-        _headers = new MultiValueDictionary<string, string>();
-        _body = new List<string>();
-        _groupsBuilder = new NntpGroupsBuilder();
-        _messageId = NntpMessageId.Empty;
     }
 
     /// <summary>
@@ -189,7 +185,7 @@ public class NntpArticleBuilder
     /// <returns>The <see cref="NntpArticleBuilder"/> so that additional calls can be chained.</returns>
     public NntpArticleBuilder SetBody(IEnumerable<string> lines)
     {
-        _body = lines.ThrowIfNull(nameof(lines));
+        _body = lines.ThrowIfNull(nameof(lines)).ToList();
         return this;
     }
 
@@ -264,31 +260,27 @@ public class NntpArticleBuilder
     }
 
     /// <summary>
-    /// Adds a line to the body of the article. This will memoize the internal body collection if needed.
+    /// Adds a line to the body of the article.
     /// </summary>
     /// <param name="line">The text line to add to the body.</param>
     /// <returns>The <see cref="NntpArticleBuilder"/> so that additional calls can be chained.</returns>
     public NntpArticleBuilder AddLine(string line)
     {
         Guard.ThrowIfNull(line, nameof(line));
-        var bodyList = EnsureMemoizedBody();
-        bodyList.Add(line);
+        _body.Add(line);
         return this;
     }
 
     /// <summary>
-    /// Adds multiple lines to the body of the article. This will memoize the internal body collection if needed.
+    /// Adds multiple lines to the body of the article.
     /// </summary>
     /// <param name="lines">The text lines to add to the body.</param>
     /// <returns>The <see cref="NntpArticleBuilder"/> so that additional calls can be chained.</returns>
     public NntpArticleBuilder AddLines(IEnumerable<string> lines)
     {
         Guard.ThrowIfNull(lines, nameof(lines));
-        var bodyList = EnsureMemoizedBody();
-        foreach (var line in lines)
-        {
-            bodyList.Add(line);
-        }
+
+        _body.AddRange(lines);
 
         return this;
     }
@@ -331,16 +323,5 @@ public class NntpArticleBuilder
         }
 
         return new NntpArticle(0, _messageId, groups, _headers, _body);
-    }
-
-    private ICollection<string> EnsureMemoizedBody()
-    {
-        if (!(_body is ICollection<string>))
-        {
-            // memoize the body lines
-            _body = _body.ToList();
-        }
-
-        return (ICollection<string>)_body;
     }
 }

--- a/Usenet/Nntp/Builders/NntpGroupsBuilder.cs
+++ b/Usenet/Nntp/Builders/NntpGroupsBuilder.cs
@@ -8,19 +8,18 @@ namespace Usenet.Nntp.Builders;
 /// </summary>
 public class NntpGroupsBuilder
 {
-    private readonly List<string> _groups;
+    private readonly List<string> _groups = [];
 
     /// <summary>
     /// The raw groups collection.
     /// </summary>
-    public IEnumerable<string> Groups => _groups;
+    public IList<string> Groups => _groups;
 
     /// <summary>
     /// Creates a new instance of the <see cref="NntpGroupsBuilder"/> class.
     /// </summary>
     public NntpGroupsBuilder()
     {
-        _groups = new List<string>();
     }
 
     /// <summary>

--- a/Usenet/Nntp/Models/NntpArticle.cs
+++ b/Usenet/Nntp/Models/NntpArticle.cs
@@ -33,7 +33,7 @@ public class NntpArticle : IEquatable<NntpArticle>
     /// <summary>
     /// The body of the <see cref="NntpArticle"/>.
     /// </summary>
-    public IEnumerable<string> Body { get; private set; }
+    public IImmutableList<string> Body { get; }
 
     /// <summary>
     /// Creates a new <see cref="NntpArticle"/> object.
@@ -48,31 +48,13 @@ public class NntpArticle : IEquatable<NntpArticle>
         NntpMessageId messageId,
         NntpGroups groups,
         IDictionary<string, ICollection<string>> headers,
-        IEnumerable<string> body)
+        IList<string> body)
     {
         Number = number;
         MessageId = messageId ?? NntpMessageId.Empty;
         Groups = groups ?? NntpGroups.Empty;
         Headers = (headers ?? MultiValueDictionary<string, string>.Empty).ToImmutableDictionaryWithLists();
-
-        switch (body)
-        {
-            case null:
-                // create empty immutable list
-                Body = new List<string>(0).ToImmutableList();
-                break;
-
-            case ICollection<string> collection:
-                // make immutable
-                Body = collection.ToImmutableList();
-                break;
-
-            default:
-                // not a collection but a stream of lines, keep enumerator
-                // this is immutable already
-                Body = body;
-                break;
-        }
+        Body = (body ?? []).ToImmutableList();
     }
 
     /// <summary>
@@ -114,18 +96,6 @@ public class NntpArticle : IEquatable<NntpArticle>
             {
                 return false;
             }
-        }
-
-        // need to memoize the enumerables for comparison
-        // otherwise they can not be used anymore after this call to equals
-        if (!(Body is ICollection<string>))
-        {
-            Body = Body.ToList();
-        }
-
-        if (!(other.Body is ICollection<string>))
-        {
-            other.Body = other.Body.ToList();
         }
 
         // compare body

--- a/Usenet/Nntp/Parsers/GroupOriginsResponseParser.cs
+++ b/Usenet/Nntp/Parsers/GroupOriginsResponseParser.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
 using Usenet.Extensions;
 using Usenet.Nntp.Models;
 using Usenet.Nntp.Responses;
@@ -18,13 +19,7 @@ internal class GroupOriginsResponseParser : IMultiLineResponseParser<NntpGroupOr
             return new NntpGroupOriginsResponse(code, message, false, []);
         }
 
-        var groupOrigins = EnumerateGroupOrigins(dataBlock);
-        if (dataBlock is ICollection<string>)
-        {
-            // no need to keep enumerator if input is not a stream
-            // memoize the items (https://en.wikipedia.org/wiki/Memoization)
-            groupOrigins = groupOrigins.ToList();
-        }
+        var groupOrigins = EnumerateGroupOrigins(dataBlock).ToImmutableList();
 
         return new NntpGroupOriginsResponse(code, message, true, groupOrigins);
     }

--- a/Usenet/Nntp/Parsers/GroupsResponseParser.cs
+++ b/Usenet/Nntp/Parsers/GroupsResponseParser.cs
@@ -32,13 +32,7 @@ internal class GroupsResponseParser : IMultiLineResponseParser<NntpGroupsRespons
             return new NntpGroupsResponse(code, message, false, []);
         }
 
-        var groups = EnumerateGroups(dataBlock);
-        if (dataBlock is ICollection<string>)
-        {
-            // no need to keep enumerator if input is not a stream
-            // memoize the items (https://en.wikipedia.org/wiki/Memoization)
-            groups = groups.ToList();
-        }
+        var groups = EnumerateGroups(dataBlock).ToList();
 
         return new NntpGroupsResponse(code, message, true, groups);
     }

--- a/Usenet/Nntp/Parsers/ListGroupResponseParser.cs
+++ b/Usenet/Nntp/Parsers/ListGroupResponseParser.cs
@@ -32,13 +32,7 @@ internal class ListGroupResponseParser : IMultiLineResponseParser<NntpGroupRespo
         _ = long.TryParse(responseSplit.Length > 2 ? responseSplit[2] : null, out var highWaterMark);
         var name = responseSplit.Length > 3 ? responseSplit[3] : string.Empty;
 
-        var articleNumbers = EnumerateArticleNumbers(dataBlock);
-        if (dataBlock is ICollection<string>)
-        {
-            // no need to keep enumerator if input is not a stream
-            // memoize the article numbers (https://en.wikipedia.org/wiki/Memoization)
-            articleNumbers = articleNumbers.ToList();
-        }
+        var articleNumbers = EnumerateArticleNumbers(dataBlock).ToList();
 
         return new NntpGroupResponse(code, message, true,
             new NntpGroup(

--- a/Usenet/Nntp/Responses/NntpGroupOriginsResponse.cs
+++ b/Usenet/Nntp/Responses/NntpGroupOriginsResponse.cs
@@ -4,8 +4,8 @@ using Usenet.Nntp.Models;
 namespace Usenet.Nntp.Responses;
 
 /// <summary>
-/// Represents a response to the 
-/// <a href="https://tools.ietf.org/html/rfc3977#section-7.6.4">LIST ACTIVE.TIMES</a> 
+/// Represents a response to the
+/// <a href="https://tools.ietf.org/html/rfc3977#section-7.6.4">LIST ACTIVE.TIMES</a>
 /// (<a href="https://tools.ietf.org/html/rfc2980#section-2.1.3">ad 1</a>) command.
 /// </summary>
 public class NntpGroupOriginsResponse : NntpResponse
@@ -13,7 +13,7 @@ public class NntpGroupOriginsResponse : NntpResponse
     /// <summary>
     /// The list of <see cref="NntpGroupOrigin"/> objects received from the server.
     /// </summary>
-    public IEnumerable<NntpGroupOrigin> GroupOrigins { get; }
+    public IImmutableList<NntpGroupOrigin> GroupOrigins { get; }
 
     /// <summary>
     /// Creates a new instance of the <see cref="NntpGroupOriginsResponse"/> class.
@@ -22,26 +22,9 @@ public class NntpGroupOriginsResponse : NntpResponse
     /// <param name="message">The response message received from the server.</param>
     /// <param name="success">A value indicating whether the command succeeded or failed.</param>
     /// <param name="groupOrigins">The list of <see cref="NntpGroupOrigin"/> objects received from the server.</param>
-    public NntpGroupOriginsResponse(int code, string message, bool success, IEnumerable<NntpGroupOrigin> groupOrigins)
+    public NntpGroupOriginsResponse(int code, string message, bool success, IList<NntpGroupOrigin> groupOrigins)
         : base(code, message, success)
     {
-        switch (groupOrigins)
-        {
-            case null:
-                // create empty immutable list
-                GroupOrigins = new List<NntpGroupOrigin>(0).ToImmutableList();
-                break;
-
-            case ICollection<NntpGroupOrigin> collection:
-                // make immutable
-                GroupOrigins = collection.ToImmutableList();
-                break;
-
-            default:
-                // not a collection but a stream of lines, keep enumerator
-                // this is immutable already
-                GroupOrigins = groupOrigins;
-                break;
-        }
+        GroupOrigins = (groupOrigins ?? []).ToImmutableList();
     }
 }

--- a/Usenet/Nntp/Responses/NntpGroupsResponse.cs
+++ b/Usenet/Nntp/Responses/NntpGroupsResponse.cs
@@ -4,11 +4,11 @@ using Usenet.Nntp.Models;
 namespace Usenet.Nntp.Responses;
 
 /// <summary>
-/// Represents a response to the 
-/// <a href="https://tools.ietf.org/html/rfc6048#section-2.2">LIST COUNTS</a>, 
-/// <a href="https://tools.ietf.org/html/rfc6048#section-3">LIST ACTIVE</a> 
+/// Represents a response to the
+/// <a href="https://tools.ietf.org/html/rfc6048#section-2.2">LIST COUNTS</a>,
+/// <a href="https://tools.ietf.org/html/rfc6048#section-3">LIST ACTIVE</a>
 /// (<a href="https://tools.ietf.org/html/rfc3977#section-7.6.3">ad 1</a>,
-/// <a href="https://tools.ietf.org/html/rfc2980#section-2.1.2">ad 2</a>) and 
+/// <a href="https://tools.ietf.org/html/rfc2980#section-2.1.2">ad 2</a>) and
 /// <a href="https://tools.ietf.org/html/rfc3977#section-7.3">NEWGROUPS</a> commands.
 /// </summary>
 public class NntpGroupsResponse : NntpResponse
@@ -16,7 +16,7 @@ public class NntpGroupsResponse : NntpResponse
     /// <summary>
     /// The list of <see cref="NntpGroup"/> objects received from the server.
     /// </summary>
-    public IEnumerable<NntpGroup> Groups { get; }
+    public IImmutableList<NntpGroup> Groups { get; }
 
     /// <summary>
     /// Creates a new instance of the <see cref="NntpGroupResponse"/> class.
@@ -25,26 +25,9 @@ public class NntpGroupsResponse : NntpResponse
     /// <param name="message">The response message received from the server.</param>
     /// <param name="success">A value indicating whether the command succeeded or failed.</param>
     /// <param name="groups">The list of <see cref="NntpGroup"/> objects received from the server.</param>
-    public NntpGroupsResponse(int code, string message, bool success, IEnumerable<NntpGroup> groups)
+    public NntpGroupsResponse(int code, string message, bool success, IList<NntpGroup> groups)
         : base(code, message, success)
     {
-        switch (groups)
-        {
-            case null:
-                // create empty immutable list
-                Groups = new List<NntpGroup>(0).ToImmutableList();
-                break;
-
-            case ICollection<NntpGroup> collection:
-                // make immutable
-                Groups = collection.ToImmutableList();
-                break;
-
-            default:
-                // not a collection but a stream of lines, keep enumerator
-                // this is immutable already
-                Groups = groups;
-                break;
-        }
+        Groups = (groups ?? []).ToImmutableList();
     }
 }

--- a/Usenet/Nntp/Responses/NntpMultiLineResponse.cs
+++ b/Usenet/Nntp/Responses/NntpMultiLineResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace Usenet.Nntp.Responses;
+﻿using System.Collections.Immutable;
+
+namespace Usenet.Nntp.Responses;
 
 /// <summary>
 /// Represents a generic multi-line response.
@@ -9,7 +11,7 @@ public class NntpMultiLineResponse : NntpResponse
     /// <summary>
     /// The lines received from the server.
     /// </summary>
-    public IEnumerable<string> Lines { get; }
+    public IImmutableList<string> Lines { get; }
 
     /// <summary>
     /// Creates a new instance of the <see cref="NntpMultiLineResponse"/> class.
@@ -24,6 +26,6 @@ public class NntpMultiLineResponse : NntpResponse
         bool success,
         IEnumerable<string> lines) : base(code, message, success)
     {
-        Lines = lines ?? [];
+        Lines = (lines ?? []).ToImmutableList();
     }
 }


### PR DESCRIPTION
While lazy evaluation is more efficient, the current implementation causes some issues.

For example:
When requesting an article, the server sends the full response for the article.
This includes both the headers and body.
The code eagerly evaluates the headers.
The code leaves to body untouched.
The body is only read from the stream when Article.Body is enumerated by the user.

If the user does not enumerate Article.Body, any subsequent commands will fail because there is still unprocessed data in the underlying stream.

Passing the code through different parsers and returning an Article object gives the impression that the data has been fully read and parsed. In additional it's currently inconsistent between commands.

This change removes any lazy evaluation left for the user to complete.