### PR TITLE
Make NNTP headers case insensitive by default

### DIFF
--- a/src/Usenet/Extensions/DictionaryExtensions.cs
+++ b/src/Usenet/Extensions/DictionaryExtensions.cs
@@ -76,14 +76,6 @@ internal static class DictionaryExtensions
         this IDictionary<TKey, ICollection<TValue>> multiValueDictionary) =>
         multiValueDictionary.ToImmutableDictionary(x => x.Key, x => x.Value.ToImmutableHashSet());
 
-    /// <summary>
-    /// Produces an immutable multi-value dictionary with immutable lists containing the values.
-    /// </summary>
-    /// <returns>An immutable multi-value dictionary with immutable lists containing the values.</returns>
-    public static ImmutableDictionary<TKey, ImmutableList<TValue>> ToImmutableDictionaryWithLists<TKey, TValue>(
-        this IDictionary<TKey, ICollection<TValue>> multiValueDictionary) =>
-        multiValueDictionary.ToImmutableDictionary(x => x.Key, x => x.Value.ToImmutableList());
-
 
     public static bool Remove<TKey, TValue>(this Dictionary<TKey, TValue> source, TKey key, [MaybeNullWhen(false)] out TValue value)
     {

--- a/src/Usenet/Nntp/Models/NntpArticle.cs
+++ b/src/Usenet/Nntp/Models/NntpArticle.cs
@@ -53,7 +53,8 @@ public class NntpArticle : IEquatable<NntpArticle>
         Number = number;
         MessageId = messageId ?? NntpMessageId.Empty;
         Groups = groups ?? NntpGroups.Empty;
-        Headers = (headers ?? MultiValueDictionary<string, string>.Empty).ToImmutableDictionaryWithLists();
+        Headers = (headers ?? MultiValueDictionary<string, string>.EmptyIgnoreCase)
+            .ToImmutableDictionary(x => x.Key, x => x.Value.ToImmutableList(), keyComparer: StringComparer.OrdinalIgnoreCase);
         Body = (body ?? []).ToImmutableList();
     }
 

--- a/src/Usenet/Nntp/Parsers/ArticleResponseParser.cs
+++ b/src/Usenet/Nntp/Parsers/ArticleResponseParser.cs
@@ -72,7 +72,7 @@ internal class ArticleResponseParser : IMultiLineResponseParser<NntpArticleRespo
         // get headers if requested
         var headers = (_requestType & ArticleRequestType.Head) == ArticleRequestType.Head
             ? GetHeaders(enumerator)
-            : MultiValueDictionary<string, string>.Empty;
+            : MultiValueDictionary<string, string>.EmptyIgnoreCase;
 
         // get groups
         var groups = headers.TryGetValue(NntpHeaders.Newsgroups, out var values)
@@ -121,7 +121,7 @@ internal class ArticleResponseParser : IMultiLineResponseParser<NntpArticleRespo
             }
         }
 
-        var dict = new MultiValueDictionary<string, string>();
+        var dict = MultiValueDictionary<string, string>.EmptyIgnoreCase;
         foreach (var header in headers)
         {
             dict.Add(header.Key, header.Value);

--- a/src/Usenet/Util/MultiValueDictionary.cs
+++ b/src/Usenet/Util/MultiValueDictionary.cs
@@ -20,10 +20,22 @@ internal class MultiValueDictionary<TKey, TValue> : Dictionary<TKey, ICollection
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey,TValue}"/>
+    /// that is empty and uses a <see cref="HashSet{TValue}"/> factor to create the internal collections.
+    /// </summary>
+    /// <param name="keyComparer"></param>
+    public MultiValueDictionary(IEqualityComparer<TKey> keyComparer)
+        : this(() => new HashSet<TValue>(), keyComparer)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey,TValue}"/>
     /// that is empty and uses the specified <paramref name="collectionFactory"/> to create the internal collections.
     /// </summary>
     /// <param name="collectionFactory">The collection factory to use.</param>
-    public MultiValueDictionary(Func<ICollection<TValue>> collectionFactory)
+    /// <param name="keyComparer"></param>
+    public MultiValueDictionary(Func<ICollection<TValue>> collectionFactory, IEqualityComparer<TKey> keyComparer = null)
+        : base(keyComparer)
     {
         _collectionFactory = collectionFactory;
     }
@@ -79,9 +91,16 @@ internal class MultiValueDictionary<TKey, TValue> : Dictionary<TKey, ICollection
     /// <summary>
     /// Represents an empty <see cref="MultiValueDictionary{TKey,TValue}"/>.
     /// </summary>
-    /// <returns>A new empty instance on every call of the <see cref="MultiValueDictionary{TKey,TValue}"/> 
+    /// <returns>A new empty instance on every call of the <see cref="MultiValueDictionary{TKey,TValue}"/>
     /// that uses a <see cref="HashSet{TValue}"/> factory internally.</returns>
-    public static MultiValueDictionary<TKey, TValue> Empty => new MultiValueDictionary<TKey, TValue>();
+    public static MultiValueDictionary<TKey, TValue> Empty => new();
+
+    /// <summary>
+    /// Represents an empty, case-insensitive, <see cref="MultiValueDictionary{TKey,TValue}"/>.
+    /// </summary>
+    /// <returns>A new empty instance on every call of the <see cref="MultiValueDictionary{TKey,TValue}"/>
+    /// that uses a <see cref="HashSet{TValue}"/> factory internally.</returns>
+    public static MultiValueDictionary<string, TValue> EmptyIgnoreCase => new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Returns the hash code for this instance.
@@ -123,7 +142,7 @@ internal class MultiValueDictionary<TKey, TValue> : Dictionary<TKey, ICollection
     public override bool Equals(object obj) => Equals(obj as MultiValueDictionary<TKey, TValue>);
 
     /// <summary>
-    /// Returns a value indicating whether the frst <see cref="MultiValueDictionary{TKey,TValue}"/> 
+    /// Returns a value indicating whether the frst <see cref="MultiValueDictionary{TKey,TValue}"/>
     /// value is equal to the second <see cref="MultiValueDictionary{TKey,TValue}"/> value.
     /// </summary>
     /// <param name="first">The first <see cref="MultiValueDictionary{TKey,TValue}"/>.</param>
@@ -133,7 +152,7 @@ internal class MultiValueDictionary<TKey, TValue> : Dictionary<TKey, ICollection
         (object)first == null ? (object)second == null : first.Equals(second);
 
     /// <summary>
-    /// Returns a value indicating whether the frst <see cref="MultiValueDictionary{TKey,TValue}"/> 
+    /// Returns a value indicating whether the frst <see cref="MultiValueDictionary{TKey,TValue}"/>
     /// value is unequal to the second <see cref="MultiValueDictionary{TKey,TValue}"/> value.
     /// </summary>
     /// <param name="first">The first <see cref="MultiValueDictionary{TKey,TValue}"/>.</param>

--- a/tests/Usenet.Tests/Util/MultiValueDictionaryTests.cs
+++ b/tests/Usenet.Tests/Util/MultiValueDictionaryTests.cs
@@ -27,6 +27,26 @@ public class MultiValueDictionaryTests
     }
 
     [Fact]
+    public void MultipleValuesWithSameKeyShouldBeAddedIgnoreCase()
+    {
+        var dict = new MultiValueDictionary<string, string>(() => new HashSet<string>(), StringComparer.OrdinalIgnoreCase)
+        {
+            { "A", "one" },
+            { "a", "een" },
+            { "B", "two" },
+            { "b", "twee" },
+            { "b", "deux" }
+        };
+
+        Assert.Equal(5, dict.Count);
+        Assert.Equal(2, dict["a"].Count);
+        Assert.Equal(3, dict["b"].Count);
+
+        Assert.True(new HashSet<string> { "one", "een" }.SetEquals(dict["a"]));
+        Assert.True(new HashSet<string> { "two", "twee", "deux" }.SetEquals(dict["b"]));
+    }
+
+    [Fact]
     public void SameValueWithSameKeyShouldNotBeAddedWhenUsingHashSet()
     {
         var dict = new MultiValueDictionary<int, string>(() => new HashSet<string>()) { { 1, "one" }, { 1, "one" }, };


### PR DESCRIPTION
Merge headers with different casing under a single key.


> The headers of an article consist of one or more header lines.  Each header line consists of a header name, a colon, a space, the header content, and a CRLF, in that order.  The name consists of one or more printable US-ASCII characters other than colon and, for the purposes of this specification, is not case sensitive.

https://www.rfc-editor.org/rfc/rfc3977