### PR TITLE
Fix potential causes of socket exhaustion

### DIFF
--- a/src/Usenet/Nntp/Contracts/IInternalPooledNntpClient.cs
+++ b/src/Usenet/Nntp/Contracts/IInternalPooledNntpClient.cs
@@ -1,0 +1,8 @@
+namespace Usenet.Nntp.Contracts;
+
+internal interface IInternalPooledNntpClient : IPooledNntpClient, INntpClient, IDisposable
+{
+    bool Connected { get; }
+    bool Authenticated { get; }
+    DateTimeOffset LastActivity { get; }
+}

--- a/src/Usenet/Nntp/Contracts/INntpClientPool.cs
+++ b/src/Usenet/Nntp/Contracts/INntpClientPool.cs
@@ -21,10 +21,9 @@ public interface INntpClientPool : IDisposable
     TimeSpan WaitTimeout { get; init; }
 
     /// <summary>
-    /// Retrieves an authenticated and connected NNTP client from the pool.
+    /// Gets a lease on an authenticated and connected NNTP client from the pool.
     /// If no clients are available, it will wait until one becomes available or the wait times out.
     /// </summary>
     /// <returns></returns>
-    Task<IPooledNntpClient> BorrowClient();
-    void ReturnClient(IPooledNntpClient client);
+    Task<IPooledNntpClientLease> GetLease();
 }

--- a/src/Usenet/Nntp/Contracts/IPooledNntpClient.cs
+++ b/src/Usenet/Nntp/Contracts/IPooledNntpClient.cs
@@ -1,9 +1,6 @@
 namespace Usenet.Nntp.Contracts;
 
 /// <summary>
-/// An NNTP client that manages its own connection lifetime and authentication for pooling.
+/// An NNTP client for which connections and authentication are managed by a pool.
 /// </summary>
-public interface IPooledNntpClient : INntpClientRfc2980, INntpClientRfc3977, INntpClientRfc6048, INntpClientCompression, IDisposable
-{
-
-}
+public interface IPooledNntpClient : INntpClientRfc2980, INntpClientRfc3977, INntpClientRfc6048, INntpClientCompression;

--- a/src/Usenet/Nntp/Contracts/IPooledNntpClientLease.cs
+++ b/src/Usenet/Nntp/Contracts/IPooledNntpClientLease.cs
@@ -1,0 +1,6 @@
+namespace Usenet.Nntp.Contracts;
+
+public interface IPooledNntpClientLease : IDisposable
+{
+    public IPooledNntpClient Client { get; }
+}

--- a/src/Usenet/Nntp/PooledNntpClient.cs
+++ b/src/Usenet/Nntp/PooledNntpClient.cs
@@ -5,15 +5,15 @@ using Usenet.Util.Compatibility;
 
 namespace Usenet.Nntp;
 
-/// <inheritdoc />
-internal class PooledNntpClient : IPooledNntpClient
+/// <inheritdoc cref="IPooledNntpClient" />
+internal sealed class PooledNntpClient : IInternalPooledNntpClient
 {
     private readonly NntpConnection _connection;
     private readonly NntpClient _client;
     private bool _disposed;
-    internal bool Connected { get; set; }
-    internal bool Authenticated { get; set; }
-    internal DateTimeOffset LastActivity { get; set; }
+    public DateTimeOffset LastActivity { get; set; }
+    public bool Connected { get; set; }
+    public bool Authenticated { get; set; }
 
     public PooledNntpClient()
     {
@@ -36,21 +36,21 @@ internal class PooledNntpClient : IPooledNntpClient
         }
     }
 
-    internal async Task<bool> ConnectAsync(string hostname, int port, bool useSsl)
+    #region INntpClient
+
+    public async Task<bool> ConnectAsync(string hostname, int port, bool useSsl)
     {
         var res = await _client.ConnectAsync(hostname, port, useSsl).ConfigureAwait(false);
         Connected = res;
         return res;
     }
 
-    internal bool Authenticate(string username, string password = null)
+    public bool Authenticate(string username, string password = null)
     {
         var res = _client.Authenticate(username, password);
         Authenticated = res;
         return res;
     }
-
-    #region INntpClient
 
     public NntpResponse XfeatureCompressGzip(bool withTerminator) => Client.XfeatureCompressGzip(withTerminator);
     public NntpMultiLineResponse Xzhdr(string field, NntpMessageId messageId) => Client.Xzhdr(field, messageId);

--- a/src/Usenet/Nntp/PooledNntpClientLease.cs
+++ b/src/Usenet/Nntp/PooledNntpClientLease.cs
@@ -1,0 +1,26 @@
+using Usenet.Nntp.Contracts;
+
+namespace Usenet.Nntp;
+
+internal sealed class PooledNntpClientLease : IPooledNntpClientLease
+{
+    private readonly NntpClientPool _pool;
+    private readonly IInternalPooledNntpClient _client;
+    private bool _disposed;
+
+    public IPooledNntpClient Client => _client;
+
+    internal PooledNntpClientLease(NntpClientPool pool, IInternalPooledNntpClient client)
+    {
+        _pool = pool;
+        _client = client;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        _pool.ReturnClient(_client);
+        _disposed = true;
+    }
+}


### PR DESCRIPTION
Addresses potential causes of socket exhaustion reported in https://github.com/Spottarr/Spottarr/issues/68.
- Ensure that all clients are disposed when the pool is disposed, even when they have been borrowed but not yet returned
- Enforce returning clients to the pool by implementing a disposable lease