### PR TITLE
Bump the nuget group with 5 updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,15 +5,15 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.7" />
+    <PackageVersion Include="System.Collections.Immutable" Version="9.0.8" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
     <PackageVersion Include="xunit.v3" Version="3.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Bumps Microsoft.Extensions.FileProviders.Abstractions from 9.0.7 to 9.0.8 Bumps Microsoft.Extensions.FileProviders.Embedded from 9.0.7 to 9.0.8 Bumps Microsoft.Extensions.Logging from 9.0.7 to 9.0.8 Bumps Microsoft.Extensions.Logging.Abstractions from 9.0.7 to 9.0.8 Bumps System.Collections.Immutable from 9.0.7 to 9.0.8

---
updated-dependencies:
- dependency-name: Microsoft.Extensions.FileProviders.Abstractions dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: nuget
- dependency-name: Microsoft.Extensions.FileProviders.Embedded dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: nuget
- dependency-name: Microsoft.Extensions.Logging dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: nuget
- dependency-name: Microsoft.Extensions.Logging.Abstractions dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: nuget
- dependency-name: System.Collections.Immutable dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: nuget ...