### PR TITLE
Recreate pooled clients in errored state

### DIFF
--- a/src/Usenet/Extensions/LogExtensions.cs
+++ b/src/Usenet/Extensions/LogExtensions.cs
@@ -57,4 +57,7 @@ internal static partial class LogExtensions
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Disposing idle NNTP client ({CurrentPoolSize}/{MaxPoolSize})")]
     public static partial void DisposingIdleNntpClient(this ILogger logger, int currentPoolSize, int maxPoolSize);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Disposing NNTP client left in an errored state after a previous operation ({CurrentPoolSize}/{MaxPoolSize})")]
+    public static partial void DisposingErroredNntpClient(this ILogger logger, int currentPoolSize, int maxPoolSize);
 }

--- a/src/Usenet/Nntp/Contracts/IInternalPooledNntpClient.cs
+++ b/src/Usenet/Nntp/Contracts/IInternalPooledNntpClient.cs
@@ -4,5 +4,6 @@ internal interface IInternalPooledNntpClient : IPooledNntpClient, INntpClient, I
 {
     bool Connected { get; }
     bool Authenticated { get; }
+    bool HasError { get; }
     DateTimeOffset LastActivity { get; }
 }

--- a/src/Usenet/Nntp/NntpClientPool.cs
+++ b/src/Usenet/Nntp/NntpClientPool.cs
@@ -94,7 +94,7 @@ public sealed class NntpClientPool : INntpClientPool
             if(!_usedClients.Remove(client))
                 throw new InvalidOperationException("Client not borrowed from this pool.");
 
-            // If the client has encountered and error (e.g. broken pipe) during the most recent operation, dispose it instead of returning it to the pool
+            // If the client has encountered an error (e.g. broken pipe) during the most recent operation, dispose it instead of returning it to the pool
             if (client.HasError)
             {
                 _currentPoolSize--;

--- a/src/Usenet/Nntp/NntpClientPool.cs
+++ b/src/Usenet/Nntp/NntpClientPool.cs
@@ -97,8 +97,9 @@ public sealed class NntpClientPool : INntpClientPool
             // If the client has encountered an error (e.g. broken pipe) during the most recent operation, dispose it instead of returning it to the pool
             if (client.HasError)
             {
-                _currentPoolSize--;
                 client.Dispose();
+                _currentPoolSize--;
+                _logger.DisposingErroredNntpClient(_currentPoolSize, _maxPoolSize);
             }
             else
             {

--- a/src/Usenet/Nntp/NntpClientPool.cs
+++ b/src/Usenet/Nntp/NntpClientPool.cs
@@ -109,7 +109,7 @@ public sealed class NntpClientPool : INntpClientPool
                 return existingClient;
             }
 
-            if (_currentPoolSize > _maxPoolSize)
+            if (_currentPoolSize >= _maxPoolSize)
                 throw new InvalidOperationException("No available clients in the pool.");
 
             _currentPoolSize++;

--- a/src/Usenet/Nntp/NntpClientPool.cs
+++ b/src/Usenet/Nntp/NntpClientPool.cs
@@ -94,7 +94,17 @@ public sealed class NntpClientPool : INntpClientPool
             if(!_usedClients.Remove(client))
                 throw new InvalidOperationException("Client not borrowed from this pool.");
 
-            _availableClients.Enqueue(client);
+            // If the client has encountered and error (e.g. broken pipe) during the most recent operation, dispose it instead of returning it to the pool
+            if (client.HasError)
+            {
+                _currentPoolSize--;
+                client.Dispose();
+            }
+            else
+            {
+                _availableClients.Enqueue(client);
+            }
+
             _semaphore.Release();
         }
     }

--- a/src/Usenet/Nntp/PooledNntpClient.cs
+++ b/src/Usenet/Nntp/PooledNntpClient.cs
@@ -13,9 +13,10 @@ internal sealed class PooledNntpClient : IInternalPooledNntpClient
     private bool _disposed;
     private bool TcpConnected => _connection.Connected;
     private bool NntpConnected { get; set; }
-    public DateTimeOffset LastActivity { get; set; }
+    public DateTimeOffset LastActivity { get; private set; }
     public bool Connected => TcpConnected && NntpConnected;
-    public bool Authenticated { get; set; }
+    public bool Authenticated { get; private set; }
+    public bool HasError { get; private set; }
 
     public PooledNntpClient()
     {
@@ -54,69 +55,69 @@ internal sealed class PooledNntpClient : IInternalPooledNntpClient
         return res;
     }
 
-    public NntpResponse XfeatureCompressGzip(bool withTerminator) => Client.XfeatureCompressGzip(withTerminator);
-    public NntpMultiLineResponse Xzhdr(string field, NntpMessageId messageId) => Client.Xzhdr(field, messageId);
-    public NntpMultiLineResponse Xzhdr(string field, NntpArticleRange range) => Client.Xzhdr(field, range);
-    public NntpMultiLineResponse Xzhdr(string field) => Client.Xzhdr(field);
-    public NntpMultiLineResponse Xzver(NntpArticleRange range) => Client.Xzver(range);
-    public NntpMultiLineResponse Xzver() => Client.Xzver();
-    public void ResetCounters() => Client.ResetCounters();
-    public NntpMultiLineResponse Xhdr(string field, NntpMessageId messageId) => Client.Xhdr(field, messageId);
-    public NntpMultiLineResponse Xhdr(string field, NntpArticleRange range) => Client.Xhdr(field, range);
-    public NntpMultiLineResponse Xhdr(string field) => Client.Xhdr(field);
-    public NntpMultiLineResponse Xover(NntpArticleRange range) => Client.Xover(range);
-    public NntpMultiLineResponse Xover() => Client.Xover();
-    public NntpMultiLineResponse Capabilities() => Client.Capabilities();
-    public NntpMultiLineResponse Capabilities(string keyword) => Client.Capabilities(keyword);
-    public NntpModeReaderResponse ModeReader() => Client.ModeReader();
-    public NntpResponse Quit() => Client.Quit();
-    public NntpGroupResponse Group(string group) => Client.Group(group);
-    public NntpGroupResponse ListGroup(string group, NntpArticleRange range) => Client.ListGroup(group, range);
-    public NntpGroupResponse ListGroup(string group) => Client.ListGroup(group);
-    public NntpGroupResponse ListGroup() => Client.ListGroup();
-    public NntpLastResponse Last() => Client.Last();
-    public NntpNextResponse Next() => Client.Next();
-    public NntpArticleResponse Article(NntpMessageId messageId) => Client.Article(messageId);
-    public NntpArticleResponse Article(long number) => Client.Article(number);
-    public NntpArticleResponse Article() => Client.Article();
-    public NntpArticleResponse Head(NntpMessageId messageId) => Client.Head(messageId);
-    public NntpArticleResponse Head(long number) => Client.Head(number);
-    public NntpArticleResponse Head() => Client.Head();
-    public NntpArticleResponse Body(NntpMessageId messageId) => Client.Body();
-    public NntpArticleResponse Body(long number) => Client.Body(number);
-    public NntpArticleResponse Body() => Client.Body();
-    public NntpStatResponse Stat(NntpMessageId messageId) => Client.Stat(messageId);
-    public NntpStatResponse Stat(long number) => Client.Stat(number);
-    public NntpStatResponse Stat() => Client.Stat();
-    public bool Post(NntpArticle article) => Client.Post(article);
-    public bool Ihave(NntpArticle article) => Client.Ihave(article);
-    public NntpDateResponse Date() => Client.Date();
-    public NntpMultiLineResponse Help() => Client.Help();
-    public NntpGroupsResponse NewGroups(NntpDateTime sinceDateTime) => Client.NewGroups(sinceDateTime);
-    public NntpMultiLineResponse NewNews(string wildmat, NntpDateTime sinceDateTime) => Client.NewNews(wildmat, sinceDateTime);
-    public NntpGroupOriginsResponse ListActiveTimes() => Client.ListActiveTimes();
-    public NntpGroupOriginsResponse ListActiveTimes(string wildmat) => Client.ListActiveTimes(wildmat);
-    public NntpMultiLineResponse ListDistribPats() => Client.ListDistribPats();
-    public NntpMultiLineResponse ListNewsgroups() => Client.ListNewsgroups();
-    public NntpMultiLineResponse ListNewsgroups(string wildmat) => Client.ListNewsgroups(wildmat);
-    public NntpMultiLineResponse Over(NntpMessageId messageId) => Client.Over(messageId);
-    public NntpMultiLineResponse Over(NntpArticleRange range) => Client.Over(range);
-    public NntpMultiLineResponse Over() => Client.Over();
-    public NntpMultiLineResponse ListOverviewFormat() => Client.ListOverviewFormat();
-    public NntpMultiLineResponse Hdr(string field, NntpMessageId messageId) => Client.Hdr(field, messageId);
-    public NntpMultiLineResponse Hdr(string field, NntpArticleRange range) => Client.Hdr(field, range);
-    public NntpMultiLineResponse Hdr(string field) => Client.Hdr(field);
-    public NntpMultiLineResponse ListHeaders(NntpMessageId messageId) => Client.ListHeaders(messageId);
-    public NntpMultiLineResponse ListHeaders(NntpArticleRange range) => Client.ListHeaders(range);
-    public NntpMultiLineResponse ListHeaders() => Client.ListHeaders();
-    public NntpGroupsResponse ListCounts() => Client.ListCounts();
-    public NntpGroupsResponse ListCounts(string wildmat) => Client.ListCounts(wildmat);
-    public NntpMultiLineResponse ListDistributions() => Client.ListDistributions();
-    public NntpMultiLineResponse ListModerators() => Client.ListModerators();
-    public NntpMultiLineResponse ListMotd() => Client.ListMotd();
-    public NntpMultiLineResponse ListSubscriptions() => Client.ListSubscriptions();
-    public NntpGroupsResponse ListActive() => Client.ListActive();
-    public NntpGroupsResponse ListActive(string wildmat) => Client.ListActive(wildmat);
+    public NntpResponse XfeatureCompressGzip(bool withTerminator) => ExecuteCommand(c => c.XfeatureCompressGzip(withTerminator));
+    public NntpMultiLineResponse Xzhdr(string field, NntpMessageId messageId) => ExecuteCommand(c => c.Xzhdr(field, messageId));
+    public NntpMultiLineResponse Xzhdr(string field, NntpArticleRange range) => ExecuteCommand(c => c.Xzhdr(field, range));
+    public NntpMultiLineResponse Xzhdr(string field) => ExecuteCommand(c => c.Xzhdr(field));
+    public NntpMultiLineResponse Xzver(NntpArticleRange range) => ExecuteCommand(c => c.Xzver(range));
+    public NntpMultiLineResponse Xzver() => ExecuteCommand(c => c.Xzver());
+    public void ResetCounters() => ExecuteCommand(c => c.ResetCounters());
+    public NntpMultiLineResponse Xhdr(string field, NntpMessageId messageId) => ExecuteCommand(c => c.Xhdr(field, messageId));
+    public NntpMultiLineResponse Xhdr(string field, NntpArticleRange range) => ExecuteCommand(c => c.Xhdr(field, range));
+    public NntpMultiLineResponse Xhdr(string field) => ExecuteCommand(c => c.Xhdr(field));
+    public NntpMultiLineResponse Xover(NntpArticleRange range) => ExecuteCommand(c => c.Xover(range));
+    public NntpMultiLineResponse Xover() => ExecuteCommand(c => c.Xover());
+    public NntpMultiLineResponse Capabilities() => ExecuteCommand(c => c.Capabilities());
+    public NntpMultiLineResponse Capabilities(string keyword) => ExecuteCommand(c => c.Capabilities(keyword));
+    public NntpModeReaderResponse ModeReader() => ExecuteCommand(c => c.ModeReader());
+    public NntpResponse Quit() => ExecuteCommand(c => c.Quit());
+    public NntpGroupResponse Group(string group) => ExecuteCommand(c => c.Group(group));
+    public NntpGroupResponse ListGroup(string group, NntpArticleRange range) => ExecuteCommand(c => c.ListGroup(group, range));
+    public NntpGroupResponse ListGroup(string group) => ExecuteCommand(c => c.ListGroup(group));
+    public NntpGroupResponse ListGroup() => ExecuteCommand(c => c.ListGroup());
+    public NntpLastResponse Last() => ExecuteCommand(c => c.Last());
+    public NntpNextResponse Next() => ExecuteCommand(c => c.Next());
+    public NntpArticleResponse Article(NntpMessageId messageId) => ExecuteCommand(c => c.Article(messageId));
+    public NntpArticleResponse Article(long number) => ExecuteCommand(c => c.Article(number));
+    public NntpArticleResponse Article() => ExecuteCommand(c => c.Article());
+    public NntpArticleResponse Head(NntpMessageId messageId) => ExecuteCommand(c => c.Head(messageId));
+    public NntpArticleResponse Head(long number) => ExecuteCommand(c => c.Head(number));
+    public NntpArticleResponse Head() => ExecuteCommand(c => c.Head());
+    public NntpArticleResponse Body(NntpMessageId messageId) => ExecuteCommand(c => c.Body());
+    public NntpArticleResponse Body(long number) => ExecuteCommand(c => c.Body(number));
+    public NntpArticleResponse Body() => ExecuteCommand(c => c.Body());
+    public NntpStatResponse Stat(NntpMessageId messageId) => ExecuteCommand(c => c.Stat(messageId));
+    public NntpStatResponse Stat(long number) => ExecuteCommand(c => c.Stat(number));
+    public NntpStatResponse Stat() => ExecuteCommand(c => c.Stat());
+    public bool Post(NntpArticle article) => ExecuteCommand(c => c.Post(article));
+    public bool Ihave(NntpArticle article) => ExecuteCommand(c => c.Ihave(article));
+    public NntpDateResponse Date() => ExecuteCommand(c => c.Date());
+    public NntpMultiLineResponse Help() => ExecuteCommand(c => c.Help());
+    public NntpGroupsResponse NewGroups(NntpDateTime sinceDateTime) => ExecuteCommand(c => c.NewGroups(sinceDateTime));
+    public NntpMultiLineResponse NewNews(string wildmat, NntpDateTime sinceDateTime) => ExecuteCommand(c => c.NewNews(wildmat, sinceDateTime));
+    public NntpGroupOriginsResponse ListActiveTimes() => ExecuteCommand(c => c.ListActiveTimes());
+    public NntpGroupOriginsResponse ListActiveTimes(string wildmat) => ExecuteCommand(c => c.ListActiveTimes(wildmat));
+    public NntpMultiLineResponse ListDistribPats() => ExecuteCommand(c => c.ListDistribPats());
+    public NntpMultiLineResponse ListNewsgroups() => ExecuteCommand(c => c.ListNewsgroups());
+    public NntpMultiLineResponse ListNewsgroups(string wildmat) => ExecuteCommand(c => c.ListNewsgroups(wildmat));
+    public NntpMultiLineResponse Over(NntpMessageId messageId) => ExecuteCommand(c => c.Over(messageId));
+    public NntpMultiLineResponse Over(NntpArticleRange range) => ExecuteCommand(c => c.Over(range));
+    public NntpMultiLineResponse Over() => ExecuteCommand(c => c.Over());
+    public NntpMultiLineResponse ListOverviewFormat() => ExecuteCommand(c => c.ListOverviewFormat());
+    public NntpMultiLineResponse Hdr(string field, NntpMessageId messageId) => ExecuteCommand(c => c.Hdr(field, messageId));
+    public NntpMultiLineResponse Hdr(string field, NntpArticleRange range) => ExecuteCommand(c => c.Hdr(field, range));
+    public NntpMultiLineResponse Hdr(string field) => ExecuteCommand(c => c.Hdr(field));
+    public NntpMultiLineResponse ListHeaders(NntpMessageId messageId) => ExecuteCommand(c => c.ListHeaders(messageId));
+    public NntpMultiLineResponse ListHeaders(NntpArticleRange range) => ExecuteCommand(c => c.ListHeaders(range));
+    public NntpMultiLineResponse ListHeaders() => ExecuteCommand(c => c.ListHeaders());
+    public NntpGroupsResponse ListCounts() => ExecuteCommand(c => c.ListCounts());
+    public NntpGroupsResponse ListCounts(string wildmat) => ExecuteCommand(c => c.ListCounts(wildmat));
+    public NntpMultiLineResponse ListDistributions() => ExecuteCommand(c => c.ListDistributions());
+    public NntpMultiLineResponse ListModerators() => ExecuteCommand(c => c.ListModerators());
+    public NntpMultiLineResponse ListMotd() => ExecuteCommand(c => c.ListMotd());
+    public NntpMultiLineResponse ListSubscriptions() => ExecuteCommand(c => c.ListSubscriptions());
+    public NntpGroupsResponse ListActive() => ExecuteCommand(c => c.ListActive());
+    public NntpGroupsResponse ListActive(string wildmat) => ExecuteCommand(c => c.ListActive(wildmat));
 
     #endregion
 
@@ -142,5 +143,31 @@ internal sealed class PooledNntpClient : IInternalPooledNntpClient
         _connection.Dispose();
 
         _disposed = true;
+    }
+
+    private T ExecuteCommand<T>(Func<NntpClient, T> command)
+    {
+        try
+        {
+            return command(Client);
+        }
+        catch (Exception)
+        {
+            HasError = true;
+            throw;
+        }
+    }
+
+    private void ExecuteCommand(Action<NntpClient> command)
+    {
+        try
+        {
+            command(Client);
+        }
+        catch (Exception)
+        {
+            HasError = true;
+            throw;
+        }
     }
 }

--- a/src/Usenet/Nntp/PooledNntpClient.cs
+++ b/src/Usenet/Nntp/PooledNntpClient.cs
@@ -24,21 +24,6 @@ internal sealed class PooledNntpClient : IInternalPooledNntpClient
         _client = new NntpClient(_connection);
     }
 
-    private NntpClient Client
-    {
-        get
-        {
-            ObjectDisposedExceptionShims.ThrowIf(_disposed, _client);
-
-            if (!Connected || !Authenticated)
-                throw new InvalidOperationException("Client not connected or authenticated");
-
-            LastActivity = DateTimeOffset.Now;
-
-            return _client;
-        }
-    }
-
     #region INntpClient
 
     public async Task<bool> ConnectAsync(string hostname, int port, bool useSsl)
@@ -143,6 +128,21 @@ internal sealed class PooledNntpClient : IInternalPooledNntpClient
         _connection.Dispose();
 
         _disposed = true;
+    }
+
+    private NntpClient Client
+    {
+        get
+        {
+            ObjectDisposedExceptionShims.ThrowIf(_disposed, _client);
+
+            if (!Connected || !Authenticated)
+                throw new InvalidOperationException("Client not connected or authenticated");
+
+            LastActivity = DateTimeOffset.Now;
+
+            return _client;
+        }
     }
 
     private T ExecuteCommand<T>(Func<NntpClient, T> command)

--- a/src/Usenet/Nntp/PooledNntpClient.cs
+++ b/src/Usenet/Nntp/PooledNntpClient.cs
@@ -124,7 +124,19 @@ internal sealed class PooledNntpClient : IInternalPooledNntpClient
     {
         if (_disposed) return;
 
-        _client.Quit();
+#pragma warning disable CA1031
+        try
+        {
+            // Try to gracefully QUIT the NNTP session
+            if (NntpConnected) _client.Quit();
+        }
+        catch
+        {
+            // It's possible that the connection is already closed or broken.
+            // We can ignore any exceptions here as we're disposing anyway.
+        }
+#pragma warning restore CA1031
+
         NntpConnected = false;
         Authenticated = false;
         _connection.Dispose();

--- a/src/Usenet/Nntp/PooledNntpClient.cs
+++ b/src/Usenet/Nntp/PooledNntpClient.cs
@@ -68,7 +68,7 @@ internal sealed class PooledNntpClient : IInternalPooledNntpClient
     public NntpArticleResponse Head(NntpMessageId messageId) => ExecuteCommand(c => c.Head(messageId));
     public NntpArticleResponse Head(long number) => ExecuteCommand(c => c.Head(number));
     public NntpArticleResponse Head() => ExecuteCommand(c => c.Head());
-    public NntpArticleResponse Body(NntpMessageId messageId) => ExecuteCommand(c => c.Body());
+    public NntpArticleResponse Body(NntpMessageId messageId) => ExecuteCommand(c => c.Body(messageId));
     public NntpArticleResponse Body(long number) => ExecuteCommand(c => c.Body(number));
     public NntpArticleResponse Body() => ExecuteCommand(c => c.Body());
     public NntpStatResponse Stat(NntpMessageId messageId) => ExecuteCommand(c => c.Stat(messageId));

--- a/tests/Usenet.Tests/Nntp/Pooling/NntpClientPoolTests.cs
+++ b/tests/Usenet.Tests/Nntp/Pooling/NntpClientPoolTests.cs
@@ -1,6 +1,8 @@
 using NSubstitute;
+using Usenet.Exceptions;
 using Usenet.Nntp;
 using Usenet.Nntp.Contracts;
+using Usenet.Tests.TestHelpers;
 using Xunit;
 
 namespace Usenet.Tests.Nntp.Pooling;
@@ -47,6 +49,38 @@ public class NntpClientPoolTests
         // Get the second lease, this should succeed because the first client was returned to the pool
         var lease2 = await pool.GetLease();
         lease2.Dispose();
+    }
+
+    [Fact]
+    public async Task DisposeClientAfterError()
+    {
+        using var server = new TestNntpServer();
+        using var pool = new NntpClientPool(1, "127.0.0.1", server.Port, false, "example.user", "example.pass") { WaitTimeout = TimeSpan.Zero };
+
+        // Get the first lease
+        var lease1 = await pool.GetLease();
+        var client1 = lease1.Client;
+        try
+        {
+            // Group command triggers disconnect on server side
+            Assert.Throws<NntpException>(() => lease1.Client.Group("some.group"));
+        }
+        finally
+        {
+            lease1.Dispose();
+        }
+
+        // The client should be disposed after the disconnect
+        Assert.Throws<ObjectDisposedException>(() => client1.Article("123"));
+
+        // Get the second lease
+        // This should return a new client
+        var lease2 = await pool.GetLease();
+        var client2 = lease2.Client;
+        lease2.Client.Article("123");
+        lease2.Dispose();
+
+        Assert.NotEqual(client1, client2);
     }
 
     private static IInternalPooledNntpClient GetClientMock()

--- a/tests/Usenet.Tests/TestHelpers/TestNntpServer.cs
+++ b/tests/Usenet.Tests/TestHelpers/TestNntpServer.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace Usenet.Tests.TestHelpers;
+
+internal sealed class TestNntpServer : IDisposable
+{
+    private readonly TcpListener _listener;
+    private readonly CancellationTokenSource _cts = new();
+
+    public int Port => ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+    public TestNntpServer()
+    {
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        _ = AcceptLoop();
+    }
+
+    private async Task AcceptLoop()
+    {
+        var cancellationToken = _cts.Token;
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            TcpClient client;
+            try
+            {
+                client = await _listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            _ = Task.Run(() => HandleClientAsync(client, cancellationToken), cancellationToken);
+        }
+    }
+
+    private static async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
+    {
+        try
+        {
+#pragma warning disable CA2007
+            var stream = client.GetStream();
+            await using var writer = new StreamWriter(stream, Encoding.ASCII);
+            using var reader = new StreamReader(stream, Encoding.ASCII, false, 1024, leaveOpen: true);
+#pragma warning restore CA2007
+            writer.NewLine = "\r\n";
+            writer.AutoFlush = true;
+
+            // Send NNTP greeting
+            await writer.WriteLineAsync("200 Dummy server ready").ConfigureAwait(false);
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+                if (line == null) break;
+
+                var (command, subCommand, arguments) = ParseCommand(line);
+                if (command == null) continue;
+
+                switch (command)
+                {
+                    case "AUTHINFO":
+                        await writer.WriteLineAsync("281 Success").ConfigureAwait(false);
+                        break;
+                    case "GROUP":
+                        // Group command is used to force immediate connection reset
+                        // so next write on client side breaks.
+                        client.Client.LingerState = new LingerOption(true, 0);
+                        return;
+                    case "QUIT":
+                        await writer.WriteLineAsync("205 Goodbye").ConfigureAwait(false);
+                        return;
+                    default:
+                        await writer.WriteLineAsync("500 Command not recognized").ConfigureAwait(false);
+                        break;
+                }
+            }
+        }
+        finally
+        {
+            client.Close();
+            client.Dispose();
+        }
+    }
+
+    private static (string? Command, string? SubCommand, string? Arguments) ParseCommand(string line)
+    {
+        var parts = line.Split(' ', 3, StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length switch
+        {
+            0 => (null, null, null),
+            1 => (parts[0].ToUpperInvariant(), null, null),
+            2 => (parts[0].ToUpperInvariant(), null, parts[1]),
+            3 => (parts[0].ToUpperInvariant(), parts[1].ToUpperInvariant(), parts[2]),
+            _ => (null, null, null)
+        };
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _listener.Stop();
+        _cts.Dispose();
+        _listener.Dispose();
+    }
+}


### PR DESCRIPTION
Fix issues when clients that encountered connection errors (e.g. broken pipes) are put back into the pool.