### PR TITLE
Add NntpHeaderCollection and allocation-light header parsing

### DIFF
--- a/src/Usenet/Nntp/Builders/NntpArticleBuilder.cs
+++ b/src/Usenet/Nntp/Builders/NntpArticleBuilder.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using Usenet.Exceptions;
 using Usenet.Extensions;
 using Usenet.Nntp.Models;
-using Usenet.Util;
 
 namespace Usenet.Nntp.Builders;
 
@@ -27,7 +26,7 @@ public class NntpArticleBuilder
         NntpHeaders.Newsgroups,
     ];
 
-    private MultiValueDictionary<string, string> _headers = [];
+    private List<KeyValuePair<string, string>> _headers = [];
     private NntpGroupsBuilder _groupsBuilder = new();
     private NntpMessageId _messageId = NntpMessageId.Empty;
     private string _from = string.Empty;
@@ -58,84 +57,81 @@ public class NntpArticleBuilder
         _dateTime = null;
         _body = [];
 
-        foreach (var header in article.Headers)
+        foreach (var (key, value) in article.Headers)
         {
-            foreach (var value in header.Value)
+            switch (key)
             {
-                switch (header.Key)
-                {
-                    case NntpHeaders.MessageId:
-                        if (!_messageId.HasValue)
-                        {
-                            _messageId = value;
-                        }
-                        else
-                        {
-                            _log.HeaderOccursMoreThanOnce(NntpHeaders.MessageId);
-                        }
+                case NntpHeaders.MessageId:
+                    if (!_messageId.HasValue)
+                    {
+                        _messageId = value;
+                    }
+                    else
+                    {
+                        _log.HeaderOccursMoreThanOnce(NntpHeaders.MessageId);
+                    }
 
-                        break;
+                    break;
 
-                    case NntpHeaders.From:
-                        if (string.IsNullOrEmpty(_from))
-                        {
-                            _from = value;
-                        }
-                        else
-                        {
-                            _log.HeaderOccursMoreThanOnce(NntpHeaders.From);
-                        }
+                case NntpHeaders.From:
+                    if (string.IsNullOrEmpty(_from))
+                    {
+                        _from = value;
+                    }
+                    else
+                    {
+                        _log.HeaderOccursMoreThanOnce(NntpHeaders.From);
+                    }
 
-                        break;
+                    break;
 
-                    case NntpHeaders.Subject:
-                        if (string.IsNullOrEmpty(_subject))
-                        {
-                            _subject = value;
-                        }
-                        else
-                        {
-                            _log.HeaderOccursMoreThanOnce(NntpHeaders.Subject);
-                        }
+                case NntpHeaders.Subject:
+                    if (string.IsNullOrEmpty(_subject))
+                    {
+                        _subject = value;
+                    }
+                    else
+                    {
+                        _log.HeaderOccursMoreThanOnce(NntpHeaders.Subject);
+                    }
 
-                        break;
+                    break;
 
-                    case NntpHeaders.Date:
-                        if (_dateTime == null)
-                        {
-                            if (
-                                DateTimeOffset.TryParseExact(
-                                    value,
-                                    DateFormat,
-                                    CultureInfo.InvariantCulture,
-                                    DateTimeStyles.None,
-                                    out var headerDateTime
-                                )
+                case NntpHeaders.Date:
+                    if (_dateTime == null)
+                    {
+                        if (
+                            DateTimeOffset.TryParseExact(
+                                value,
+                                DateFormat,
+                                CultureInfo.InvariantCulture,
+                                DateTimeStyles.None,
+                                out var headerDateTime
                             )
-                            {
-                                _dateTime = headerDateTime;
-                            }
-                            else
-                            {
-                                _log.InvalidHeader(NntpHeaders.Date, value);
-                            }
+                        )
+                        {
+                            _dateTime = headerDateTime;
                         }
                         else
                         {
-                            _log.HeaderOccursMoreThanOnce(NntpHeaders.Date);
+                            _log.InvalidHeader(NntpHeaders.Date, value);
                         }
+                    }
+                    else
+                    {
+                        _log.HeaderOccursMoreThanOnce(NntpHeaders.Date);
+                    }
 
-                        break;
+                    break;
 
-                    case NntpHeaders.Newsgroups:
-                        // convert group header to list of groups, do not add as header
-                        _groupsBuilder.Add(value);
-                        break;
+                case NntpHeaders.Newsgroups:
+                    // convert group header to list of groups, do not add as header
+                    _groupsBuilder.Add(value);
+                    break;
 
-                    default:
-                        _headers.Add(header.Key, value);
-                        break;
-                }
+                default:
+                    _headers.Add(new(key, value));
+                    break;
             }
         }
 
@@ -250,7 +246,7 @@ public class NntpArticleBuilder
             throw new NntpException(Resources.Nntp.ReservedHeaderKeyNotAllowed);
         }
 
-        _headers.Add(key, value);
+        _headers.Add(new(key, value));
         return this;
     }
 
@@ -269,7 +265,15 @@ public class NntpArticleBuilder
             throw new NntpException(Resources.Nntp.ReservedHeaderKeyNotAllowed);
         }
 
-        _headers.Remove(key, value);
+        var index = _headers.FindIndex(h =>
+            StringComparer.OrdinalIgnoreCase.Equals(h.Key, key)
+            && StringComparer.Ordinal.Equals(h.Value, value)
+        );
+        if (index >= 0)
+        {
+            _headers.RemoveAt(index);
+        }
+
         return this;
     }
 
@@ -327,17 +331,23 @@ public class NntpArticleBuilder
 
         var groups = _groupsBuilder.Build();
 
-        _headers.Add(NntpHeaders.From, _from);
-        _headers.Add(NntpHeaders.Subject, _subject);
+        _headers.Add(new(NntpHeaders.From, _from));
+        _headers.Add(new(NntpHeaders.Subject, _subject));
 
         if (!_dateTime.HasValue)
-            return new NntpArticle(0, _messageId, groups, _headers, _body);
+            return new NntpArticle(
+                0,
+                _messageId,
+                groups,
+                new NntpHeaderCollection(_headers),
+                _body
+            );
 
         var formattedDate = _dateTime
             .Value.ToUniversalTime()
             .ToString(DateFormat, CultureInfo.InvariantCulture);
-        _headers.Add(NntpHeaders.Date, $"{formattedDate} +0000");
+        _headers.Add(new(NntpHeaders.Date, $"{formattedDate} +0000"));
 
-        return new NntpArticle(0, _messageId, groups, _headers, _body);
+        return new NntpArticle(0, _messageId, groups, new NntpHeaderCollection(_headers), _body);
     }
 }

--- a/src/Usenet/Nntp/Models/NntpArticle.cs
+++ b/src/Usenet/Nntp/Models/NntpArticle.cs
@@ -27,9 +27,9 @@ public class NntpArticle : IEquatable<NntpArticle>
     public NntpGroups Groups { get; }
 
     /// <summary>
-    /// The header dictionary of the <see cref="NntpArticle"/>.
+    /// The headers of the <see cref="NntpArticle"/>.
     /// </summary>
-    public ImmutableDictionary<string, ImmutableList<string>> Headers { get; }
+    public NntpHeaderCollection Headers { get; }
 
     /// <summary>
     /// The body of the <see cref="NntpArticle"/>.
@@ -48,18 +48,14 @@ public class NntpArticle : IEquatable<NntpArticle>
         long number,
         NntpMessageId messageId,
         NntpGroups groups,
-        IDictionary<string, ICollection<string>> headers,
+        NntpHeaderCollection headers,
         IList<string> body
     )
     {
         Number = number;
         MessageId = messageId;
         Groups = groups;
-        Headers = headers.ToImmutableDictionary(
-            x => x.Key,
-            x => x.Value.ToImmutableList(),
-            keyComparer: StringComparer.OrdinalIgnoreCase
-        );
+        Headers = headers;
         Body = body.ToImmutableList();
     }
 
@@ -82,23 +78,12 @@ public class NntpArticle : IEquatable<NntpArticle>
         var equals =
             Number.Equals(other.Number)
             && MessageId.Equals(other.MessageId)
-            && Groups.Equals(other.Groups);
+            && Groups.Equals(other.Groups)
+            && Headers.Equals(other.Headers);
 
         if (!equals)
         {
             return false;
-        }
-
-        // compare headers
-        foreach (var pair in Headers)
-        {
-            if (
-                !other.Headers.TryGetValue(pair.Key, out var value)
-                || !pair.Value.ToImmutableHashSet().SetEquals(value)
-            )
-            {
-                return false;
-            }
         }
 
         // compare body

--- a/src/Usenet/Nntp/Models/NntpHeaderCollection.cs
+++ b/src/Usenet/Nntp/Models/NntpHeaderCollection.cs
@@ -1,0 +1,191 @@
+using System.Collections;
+using JetBrains.Annotations;
+
+namespace Usenet.Nntp.Models;
+
+/// <summary>
+/// Represents an order-preserving, case-insensitive collection of NNTP header fields.
+/// A header key may occur more than once; every occurrence is kept in the order it was parsed.
+/// The collection is backed by a flat array of key/value pairs and looks up values without allocating.
+/// </summary>
+[PublicAPI]
+public sealed class NntpHeaderCollection
+    : IReadOnlyList<KeyValuePair<string, string>>,
+        IEquatable<NntpHeaderCollection>
+{
+    private readonly KeyValuePair<string, string>[] _headers;
+
+    /// <summary>
+    /// Represents the empty <see cref="NntpHeaderCollection"/>.
+    /// </summary>
+    public static NntpHeaderCollection Empty { get; } = new([]);
+
+    internal NntpHeaderCollection(IReadOnlyCollection<KeyValuePair<string, string>> headers)
+    {
+        ArgumentNullException.ThrowIfNull(headers);
+        _headers = headers as KeyValuePair<string, string>[] ?? [.. headers];
+    }
+
+    /// <summary>
+    /// Gets the number of header fields in the collection.
+    /// </summary>
+    public int Count => _headers.Length;
+
+    /// <summary>
+    /// Gets the header field at the specified index.
+    /// </summary>
+    /// <param name="index">The zero-based index of the header field to get.</param>
+    /// <returns>The header field at the specified index.</returns>
+    public KeyValuePair<string, string> this[int index] => _headers[index];
+
+    /// <summary>
+    /// Determines whether the collection contains a header field with the specified key.
+    /// </summary>
+    /// <param name="key">The key to locate.</param>
+    /// <returns><see langword="true"/> if a header field with the key exists; otherwise, <see langword="false"/>.</returns>
+    public bool Contains(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        foreach (var header in _headers)
+        {
+            if (StringComparer.OrdinalIgnoreCase.Equals(header.Key, key))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the value of the first header field with the specified key.
+    /// </summary>
+    /// <param name="key">The key to locate.</param>
+    /// <param name="value">When this method returns, contains the value of the first matching header field, if found.</param>
+    /// <returns><see langword="true"/> if a header field with the key exists; otherwise, <see langword="false"/>.</returns>
+    public bool TryGetValue(string key, out string value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        foreach (var header in _headers)
+        {
+            if (StringComparer.OrdinalIgnoreCase.Equals(header.Key, key))
+            {
+                value = header.Value;
+                return true;
+            }
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Gets all values of the header fields with the specified key, in the order they occur.
+    /// </summary>
+    /// <param name="key">The key to locate.</param>
+    /// <returns>The values of every matching header field.</returns>
+    public IEnumerable<string> GetValues(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        foreach (var header in _headers)
+        {
+            if (StringComparer.OrdinalIgnoreCase.Equals(header.Key, key))
+                yield return header.Value;
+        }
+    }
+
+    /// <summary>
+    /// Returns an enumerator that iterates through the header fields in order.
+    /// </summary>
+    /// <returns>An enumerator for the header fields.</returns>
+    public IEnumerator<KeyValuePair<string, string>> GetEnumerator() =>
+        ((IEnumerable<KeyValuePair<string, string>>)_headers).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _headers.GetEnumerator();
+
+    /// <summary>
+    /// Returns the hash code for this instance.
+    /// </summary>
+    /// <returns>A 32-bit signed integer hash code.</returns>
+    public override int GetHashCode()
+    {
+        // Order-independent so that two collections that are equal regardless of header order hash the same.
+        var hash = 0;
+        foreach (var header in _headers)
+        {
+            hash += HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(header.Key),
+                StringComparer.Ordinal.GetHashCode(header.Value)
+            );
+        }
+
+        return hash;
+    }
+
+    /// <summary>
+    /// Returns a value indicating whether this instance is equal to the specified <see cref="NntpHeaderCollection"/> value.
+    /// Header order does not affect equality, but keys are compared case-insensitively and values are compared as a multiset per key.
+    /// </summary>
+    /// <param name="other">A <see cref="NntpHeaderCollection"/> object to compare to this instance.</param>
+    /// <returns>true if <paramref name="other" /> has the same value as this instance; otherwise, false.</returns>
+    public bool Equals(NntpHeaderCollection? other)
+    {
+        if (other is null)
+            return false;
+        if (ReferenceEquals(this, other))
+            return true;
+        if (_headers.Length != other._headers.Length)
+            return false;
+
+        // Multiset comparison: every header in this collection must be matched by a distinct header in the other.
+        var matched = new bool[other._headers.Length];
+        foreach (var header in _headers)
+        {
+            var found = false;
+            for (var i = 0; i < other._headers.Length; i++)
+            {
+                if (matched[i] || !PairEquals(header, other._headers[i]))
+                    continue;
+
+                matched[i] = true;
+                found = true;
+                break;
+            }
+
+            if (!found)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool PairEquals(
+        KeyValuePair<string, string> first,
+        KeyValuePair<string, string> second
+    ) =>
+        StringComparer.OrdinalIgnoreCase.Equals(first.Key, second.Key)
+        && StringComparer.Ordinal.Equals(first.Value, second.Value);
+
+    /// <summary>
+    /// Returns a value indicating whether this instance is equal to the specified <see cref="NntpHeaderCollection"/> value.
+    /// </summary>
+    /// <param name="obj">An <see cref="object"/> to compare to this instance.</param>
+    /// <returns>true if <paramref name="obj" /> has the same value as this instance; otherwise, false.</returns>
+    public override bool Equals(object? obj) => Equals(obj as NntpHeaderCollection);
+
+    /// <summary>
+    /// Returns a value indicating whether the first <see cref="NntpHeaderCollection"/> value is equal to the second <see cref="NntpHeaderCollection"/> value.
+    /// </summary>
+    /// <param name="first">The first <see cref="NntpHeaderCollection"/>.</param>
+    /// <param name="second">The second <see cref="NntpHeaderCollection"/>.</param>
+    /// <returns>true if <paramref name="first"/> has the same value as <paramref name="second"/>; otherwise false.</returns>
+    public static bool operator ==(NntpHeaderCollection? first, NntpHeaderCollection? second) =>
+        first?.Equals(second) ?? second is null;
+
+    /// <summary>
+    /// Returns a value indicating whether the first <see cref="NntpHeaderCollection"/> value is unequal to the second <see cref="NntpHeaderCollection"/> value.
+    /// </summary>
+    /// <param name="first">The first <see cref="NntpHeaderCollection"/>.</param>
+    /// <param name="second">The second <see cref="NntpHeaderCollection"/>.</param>
+    /// <returns>true if <paramref name="first"/> has a different value than <paramref name="second"/>; otherwise false.</returns>
+    public static bool operator !=(NntpHeaderCollection? first, NntpHeaderCollection? second) =>
+        !(first == second);
+}

--- a/src/Usenet/Nntp/Parsers/ArticleResponseParser.cs
+++ b/src/Usenet/Nntp/Parsers/ArticleResponseParser.cs
@@ -3,7 +3,6 @@ using Usenet.Extensions;
 using Usenet.Nntp.Builders;
 using Usenet.Nntp.Models;
 using Usenet.Nntp.Responses;
-using Usenet.Util;
 
 namespace Usenet.Nntp.Parsers;
 
@@ -57,11 +56,11 @@ internal class ArticleResponseParser : IMultiLineResponseParser<NntpArticleRespo
         var headers =
             (_requestType & ArticleRequestType.Head) == ArticleRequestType.Head
                 ? GetHeaders(enumerator)
-                : MultiValueDictionary<string, string>.EmptyIgnoreCase;
+                : NntpHeaderCollection.Empty;
 
         // get groups
-        var groups = headers.TryGetValue(NntpHeaders.Newsgroups, out var values)
-            ? new NntpGroupsBuilder().Add(values).Build()
+        var groups = headers.Contains(NntpHeaders.Newsgroups)
+            ? new NntpGroupsBuilder().Add(headers.GetValues(NntpHeaders.Newsgroups)).Build()
             : NntpGroups.Empty;
 
         // get body if requested
@@ -78,10 +77,11 @@ internal class ArticleResponseParser : IMultiLineResponseParser<NntpArticleRespo
         );
     }
 
-    private MultiValueDictionary<string, string> GetHeaders(IEnumerator<string> enumerator)
+    private NntpHeaderCollection GetHeaders(IEnumerator<string> enumerator)
     {
-        var headers = new List<Header>();
-        Header? prevHeader = null;
+        // Parse each header line once into a flat list of key/value pairs, preserving order.
+        // Folded continuation lines are appended onto the previous pair's value in place.
+        var headers = new List<KeyValuePair<string, string>>();
         while (enumerator.MoveNext())
         {
             var line = enumerator.Current;
@@ -91,9 +91,13 @@ internal class ArticleResponseParser : IMultiLineResponseParser<NntpArticleRespo
                 break;
             }
 
-            if (char.IsWhiteSpace(line[0]) && prevHeader != null)
+            if (char.IsWhiteSpace(line[0]) && headers.Count > 0)
             {
-                prevHeader.Value += " " + line.Trim();
+                var previous = headers[^1];
+                headers[^1] = new KeyValuePair<string, string>(
+                    previous.Key,
+                    previous.Value + " " + line.Trim()
+                );
             }
             else
             {
@@ -104,19 +108,12 @@ internal class ArticleResponseParser : IMultiLineResponseParser<NntpArticleRespo
                 }
                 else
                 {
-                    prevHeader = new Header(line[..splitPos], line[(splitPos + 1)..].Trim());
-                    headers.Add(prevHeader);
+                    headers.Add(new(line[..splitPos], line[(splitPos + 1)..].Trim()));
                 }
             }
         }
 
-        var dict = MultiValueDictionary<string, string>.EmptyIgnoreCase;
-        foreach (var header in headers)
-        {
-            dict.Add(header.Key, header.Value);
-        }
-
-        return dict;
+        return headers.Count == 0 ? NntpHeaderCollection.Empty : new NntpHeaderCollection(headers);
     }
 
     private static IEnumerable<string> GetBody(IEnumerator<string> enumerator)
@@ -125,18 +122,6 @@ internal class ArticleResponseParser : IMultiLineResponseParser<NntpArticleRespo
         {
             if (enumerator.Current is not null)
                 yield return enumerator.Current;
-        }
-    }
-
-    private class Header
-    {
-        public string Key { get; }
-        public string Value { get; set; }
-
-        public Header(string key, string value)
-        {
-            Key = key;
-            Value = value;
         }
     }
 }

--- a/src/Usenet/Nntp/Writers/ArticleWriter.cs
+++ b/src/Usenet/Nntp/Writers/ArticleWriter.cs
@@ -39,19 +39,15 @@ internal static class ArticleWriter
                 cancellationToken
             )
             .ConfigureAwait(false);
-        foreach (var header in article.Headers)
+        foreach (var (key, value) in article.Headers)
         {
-            if (header.Key is NntpHeaders.MessageId or NntpHeaders.Newsgroups)
+            if (key is NntpHeaders.MessageId or NntpHeaders.Newsgroups)
             {
                 // skip message-id and newsgroups, they are already written
                 continue;
             }
 
-            foreach (var value in header.Value)
-            {
-                await WriteHeaderAsync(connection, header.Key, value, cancellationToken)
-                    .ConfigureAwait(false);
-            }
+            await WriteHeaderAsync(connection, key, value, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/src/Usenet/PublicAPI.Unshipped.txt
+++ b/src/Usenet/PublicAPI.Unshipped.txt
@@ -1,4 +1,19 @@
 #nullable enable
+*REMOVED*Usenet.Nntp.Models.NntpArticle.Headers.get -> System.Collections.Immutable.ImmutableDictionary<string!, System.Collections.Immutable.ImmutableList<string!>!>!
+Usenet.Nntp.Models.NntpArticle.Headers.get -> Usenet.Nntp.Models.NntpHeaderCollection!
+Usenet.Nntp.Models.NntpHeaderCollection
+Usenet.Nntp.Models.NntpHeaderCollection.Contains(string! key) -> bool
+Usenet.Nntp.Models.NntpHeaderCollection.Count.get -> int
+Usenet.Nntp.Models.NntpHeaderCollection.Equals(Usenet.Nntp.Models.NntpHeaderCollection? other) -> bool
+Usenet.Nntp.Models.NntpHeaderCollection.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string!, string!>>!
+Usenet.Nntp.Models.NntpHeaderCollection.GetValues(string! key) -> System.Collections.Generic.IEnumerable<string!>!
+Usenet.Nntp.Models.NntpHeaderCollection.this[int index].get -> System.Collections.Generic.KeyValuePair<string!, string!>
+Usenet.Nntp.Models.NntpHeaderCollection.TryGetValue(string! key, out string! value) -> bool
+override Usenet.Nntp.Models.NntpHeaderCollection.Equals(object? obj) -> bool
+override Usenet.Nntp.Models.NntpHeaderCollection.GetHashCode() -> int
+static Usenet.Nntp.Models.NntpHeaderCollection.Empty.get -> Usenet.Nntp.Models.NntpHeaderCollection!
+static Usenet.Nntp.Models.NntpHeaderCollection.operator !=(Usenet.Nntp.Models.NntpHeaderCollection? first, Usenet.Nntp.Models.NntpHeaderCollection? second) -> bool
+static Usenet.Nntp.Models.NntpHeaderCollection.operator ==(Usenet.Nntp.Models.NntpHeaderCollection? first, Usenet.Nntp.Models.NntpHeaderCollection? second) -> bool
 static Usenet.Yenc.YencEncoder.EncodeAsync(Usenet.Yenc.YencHeader! header, System.IO.Stream! stream, System.Buffers.IBufferWriter<byte>! writer) -> System.Threading.Tasks.Task!
 static Usenet.Yenc.YencEncoder.EncodeAsync(Usenet.Yenc.YencHeader! header, System.IO.Stream! stream, System.Buffers.IBufferWriter<byte>! writer, System.Text.Encoding! encoding) -> System.Threading.Tasks.Task!
 static Usenet.Yenc.YencEncoder.EncodeAsync(Usenet.Yenc.YencHeader! header, System.IO.Stream! stream, System.Buffers.IBufferWriter<byte>! writer, System.Text.Encoding! encoding, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!

--- a/tests/Usenet.Tests/Nntp/Builders/NntpArticleBuilderTests.cs
+++ b/tests/Usenet.Tests/Nntp/Builders/NntpArticleBuilderTests.cs
@@ -1,9 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using Usenet.Exceptions;
+﻿using Usenet.Exceptions;
 using Usenet.Nntp;
 using Usenet.Nntp.Builders;
 using Usenet.Nntp.Models;
-using Usenet.Util;
 
 namespace Usenet.Tests.Nntp.Builders;
 
@@ -141,20 +139,18 @@ internal sealed class NntpArticleBuilderTests
     }
 
     [Test]
-    [SuppressMessage("ReSharper", "DuplicateKeyCollectionInitialization")]
     public async Task BuildShouldBuildArticle()
     {
         var expected = new NntpArticle(
             0,
             "123@hhh.net",
             "alt.test;alt.testclient",
-            new MultiValueDictionary<string, string>
-            {
-                { NntpHeaders.Subject, "subject" },
-                { NntpHeaders.From, "superuser" },
-                { "Header1", "Value1" },
-                { "Header1", "Value2" },
-            },
+            new NntpHeaderCollection([
+                new(NntpHeaders.Subject, "subject"),
+                new(NntpHeaders.From, "superuser"),
+                new("Header1", "Value1"),
+                new("Header1", "Value2"),
+            ]),
             []
         );
 
@@ -174,20 +170,18 @@ internal sealed class NntpArticleBuilderTests
     }
 
     [Test]
-    [SuppressMessage("ReSharper", "DuplicateKeyCollectionInitialization")]
     public async Task BuildInitializedFromExistingArticleShouldBuildSameArticle()
     {
         var expected = new NntpArticle(
             0,
             "123@hhh.net",
             "alt.test;alt.testclient",
-            new MultiValueDictionary<string, string>
-            {
-                { NntpHeaders.Subject, "subject" },
-                { NntpHeaders.From, "superuser" },
-                { "Header1", "Value1" },
-                { "Header1", "Value2" },
-            },
+            new NntpHeaderCollection([
+                new(NntpHeaders.Subject, "subject"),
+                new(NntpHeaders.From, "superuser"),
+                new("Header1", "Value1"),
+                new("Header1", "Value2"),
+            ]),
             []
         );
 

--- a/tests/Usenet.Tests/Nntp/Models/NntpArticleTests.cs
+++ b/tests/Usenet.Tests/Nntp/Models/NntpArticleTests.cs
@@ -1,26 +1,22 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using Usenet.Nntp.Models;
-using Usenet.Util;
+﻿using Usenet.Nntp.Models;
 
 namespace Usenet.Tests.Nntp.Models;
 
 internal sealed class NntpArticleTests
 {
     [Test]
-    [SuppressMessage("ReSharper", "DuplicateKeyCollectionInitialization")]
     internal async Task EqualsWithSameValuesShouldReturnTrue()
     {
         var article1 = new NntpArticle(
             0,
             "123@bla.nl",
             NntpGroups.Empty,
-            new MultiValueDictionary<string, string>
-            {
-                { "h1", "val1" },
-                { "h3", "val3" },
-                { "h2", "val2" },
-                { "h3", "val4" },
-            },
+            new NntpHeaderCollection([
+                new("h1", "val1"),
+                new("h3", "val3"),
+                new("h2", "val2"),
+                new("h3", "val4"),
+            ]),
             new List<string>(0)
         );
 
@@ -28,13 +24,12 @@ internal sealed class NntpArticleTests
             0,
             "123@bla.nl",
             NntpGroups.Empty,
-            new MultiValueDictionary<string, string>
-            {
-                { "h3", "val4" },
-                { "h3", "val3" },
-                { "h2", "val2" },
-                { "h1", "val1" },
-            },
+            new NntpHeaderCollection([
+                new("h3", "val4"),
+                new("h3", "val3"),
+                new("h2", "val2"),
+                new("h1", "val1"),
+            ]),
             new List<string>(0)
         );
 

--- a/tests/Usenet.Tests/Nntp/Models/NntpHeaderCollectionTests.cs
+++ b/tests/Usenet.Tests/Nntp/Models/NntpHeaderCollectionTests.cs
@@ -1,0 +1,98 @@
+using Usenet.Nntp.Models;
+
+namespace Usenet.Tests.Nntp.Models;
+
+internal sealed class NntpHeaderCollectionTests
+{
+    private static readonly string[] ExpectedKeys = ["Path", "References", "References", "Subject"];
+    private static readonly string[] ExpectedReferences =
+    [
+        "<parent-1@example.com>",
+        "<parent-2@example.com>",
+    ];
+
+    private static NntpHeaderCollection Build() =>
+        new([
+            new("Path", "news.example.com!not-for-mail"),
+            new("References", "<parent-1@example.com>"),
+            new("References", "<parent-2@example.com>"),
+            new("Subject", "Example"),
+        ]);
+
+    [Test]
+    public async Task ShouldPreserveOrder()
+    {
+        var headers = Build();
+
+        var keys = headers.Select(h => h.Key).ToArray();
+
+        await Assert.That(keys).IsEquivalentTo(ExpectedKeys);
+    }
+
+    [Test]
+    public async Task LookupShouldBeCaseInsensitive()
+    {
+        var headers = Build();
+
+        await Assert.That(headers.Contains("path")).IsTrue();
+        await Assert.That(headers.TryGetValue("SUBJECT", out var value)).IsTrue();
+        await Assert.That(value).IsEqualTo("Example");
+    }
+
+    [Test]
+    public async Task TryGetValueShouldReturnFirstValue()
+    {
+        var headers = Build();
+
+        await Assert.That(headers.TryGetValue("References", out var value)).IsTrue();
+        await Assert.That(value).IsEqualTo("<parent-1@example.com>");
+    }
+
+    [Test]
+    public async Task TryGetValueForMissingKeyShouldReturnFalse()
+    {
+        var headers = Build();
+
+        await Assert.That(headers.TryGetValue("Missing", out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task GetValuesShouldReturnEveryValueForKey()
+    {
+        var headers = Build();
+
+        var values = headers.GetValues("references").ToArray();
+
+        await Assert.That(values).IsEquivalentTo(ExpectedReferences);
+    }
+
+    [Test]
+    public async Task EqualsShouldBeOrderIndependent()
+    {
+        var first = new NntpHeaderCollection([new("h1", "v1"), new("h2", "v2"), new("h2", "v3")]);
+        var second = new NntpHeaderCollection([new("h2", "v3"), new("h1", "v1"), new("h2", "v2")]);
+
+        await Assert.That(first).IsEqualTo(second);
+        await Assert.That(first == second).IsTrue();
+        await Assert.That(first.GetHashCode()).IsEqualTo(second.GetHashCode());
+    }
+
+    [Test]
+    public async Task EqualsShouldBeCaseInsensitiveOnKeys()
+    {
+        var first = new NntpHeaderCollection([new("Subject", "Example")]);
+        var second = new NntpHeaderCollection([new("subject", "Example")]);
+
+        await Assert.That(first).IsEqualTo(second);
+    }
+
+    [Test]
+    public async Task EqualsWithDifferentValuesShouldReturnFalse()
+    {
+        var first = new NntpHeaderCollection([new("h1", "v1"), new("h1", "v2")]);
+        var second = new NntpHeaderCollection([new("h1", "v1"), new("h1", "v3")]);
+
+        await Assert.That(first).IsNotEqualTo(second);
+        await Assert.That(first != second).IsTrue();
+    }
+}

--- a/tests/Usenet.Tests/Nntp/Parsers/ArticleResponseParserTests.cs
+++ b/tests/Usenet.Tests/Nntp/Parsers/ArticleResponseParserTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text;
 using Usenet.Nntp.Models;
 using Usenet.Nntp.Parsers;
-using Usenet.Util;
 
 namespace Usenet.Tests.Nntp.Parsers;
 
@@ -19,7 +18,7 @@ internal sealed class ArticleResponseParserTests
                     123,
                     "<123@poster.com>",
                     NntpGroups.Empty,
-                    MultiValueDictionary<string, string>.EmptyIgnoreCase,
+                    NntpHeaderCollection.Empty,
                     new List<string>(0)
                 )
             );
@@ -40,11 +39,10 @@ internal sealed class ArticleResponseParserTests
                     123,
                     "<123@poster.com>",
                     NntpGroups.Empty,
-                    new MultiValueDictionary<string, string>
-                    {
-                        { "Path", "pathost!demo!whitehouse!not-for-mail" },
-                        { "From", "\"Demo User\" <nobody@example.net>" },
-                    },
+                    new NntpHeaderCollection([
+                        new("Path", "pathost!demo!whitehouse!not-for-mail"),
+                        new("From", "\"Demo User\" <nobody@example.net>"),
+                    ]),
                     new List<string> { "This is just a test article (1).", "With two lines." }
                 )
             );
@@ -59,7 +57,7 @@ internal sealed class ArticleResponseParserTests
                     123,
                     "<123@poster.com>",
                     NntpGroups.Empty,
-                    MultiValueDictionary<string, string>.EmptyIgnoreCase,
+                    NntpHeaderCollection.Empty,
                     new List<string> { "This is just a test article (2).", "With two lines." }
                 )
             );
@@ -74,11 +72,10 @@ internal sealed class ArticleResponseParserTests
                     123,
                     "<123@poster.com>",
                     NntpGroups.Empty,
-                    new MultiValueDictionary<string, string>
-                    {
-                        { "Multi", "line1 line2 line3" },
-                        { "Path", "pathost!demo!whitehouse!not-for-mail" },
-                    },
+                    new NntpHeaderCollection([
+                        new("Multi", "line1 line2 line3"),
+                        new("Path", "pathost!demo!whitehouse!not-for-mail"),
+                    ]),
                     new List<string>(0)
                 )
             );
@@ -93,10 +90,7 @@ internal sealed class ArticleResponseParserTests
                     123,
                     "<123@poster.com>",
                     NntpGroups.Empty,
-                    new MultiValueDictionary<string, string>
-                    {
-                        { "Path", "pathost!demo!whitehouse!not-for-mail" },
-                    },
+                    new NntpHeaderCollection([new("Path", "pathost!demo!whitehouse!not-for-mail")]),
                     new List<string>(0)
                 )
             );

--- a/tests/Usenet.Tests/Nntp/Writers/ArticleWriterTests.cs
+++ b/tests/Usenet.Tests/Nntp/Writers/ArticleWriterTests.cs
@@ -2,7 +2,6 @@ using Usenet.Nntp.Contracts;
 using Usenet.Nntp.Models;
 using Usenet.Nntp.Parsers;
 using Usenet.Nntp.Writers;
-using Usenet.Util;
 
 namespace Usenet.Tests.Nntp.Writers;
 
@@ -16,7 +15,7 @@ internal sealed class ArticleWriterTests
                     0,
                     "1@example.com",
                     "group",
-                    MultiValueDictionary<string, string>.EmptyIgnoreCase,
+                    NntpHeaderCollection.Empty,
                     new List<string>(0)
                 ),
                 ["Message-ID: <1@example.com>", "Newsgroups: group", "", "."]
@@ -28,7 +27,7 @@ internal sealed class ArticleWriterTests
                     0,
                     "<2@example.com>",
                     "group",
-                    MultiValueDictionary<string, string>.EmptyIgnoreCase,
+                    NntpHeaderCollection.Empty,
                     new List<string>(0)
                 ),
                 ["Message-ID: <2@example.com>", "Newsgroups: group", "", "."]
@@ -40,10 +39,7 @@ internal sealed class ArticleWriterTests
                     0,
                     "3@example.com",
                     "group",
-                    new MultiValueDictionary<string, string>
-                    {
-                        { "From", "\"Demo User\" <nobody@example.net>" },
-                    },
+                    new NntpHeaderCollection([new("From", "\"Demo User\" <nobody@example.net>")]),
                     new List<string> { "This is just a test article." }
                 ),
                 [
@@ -62,10 +58,7 @@ internal sealed class ArticleWriterTests
                     0,
                     "4@example.com",
                     "group",
-                    new MultiValueDictionary<string, string>
-                    {
-                        { "Message-ID", "<9999@example.com>" },
-                    },
+                    new NntpHeaderCollection([new("Message-ID", "<9999@example.com>")]),
                     new List<string> { "This is just a test article." }
                 ),
                 [
@@ -83,10 +76,7 @@ internal sealed class ArticleWriterTests
                     0,
                     "5@example.com",
                     "group",
-                    new MultiValueDictionary<string, string>
-                    {
-                        { "Message-ID", "9999@example.com" },
-                    },
+                    new NntpHeaderCollection([new("Message-ID", "9999@example.com")]),
                     new List<string> { "This is just a test article." }
                 ),
                 [


### PR DESCRIPTION
Closes #118 (do not auto-close yet — leaving open per process).

## What changed

Replaces the allocation-heavy article header model with a purpose-built collection parsed directly from the header lines.

- **New `NntpHeaderCollection`** (`Usenet.Nntp.Models`): order-preserving, case-insensitive, multi-valued, backed by a flat `KeyValuePair<string,string>[]`. `Contains`/`TryGetValue`/`GetValues` scan the array without allocating. Equality is order-independent with case-insensitive keys and per-key value multiset comparison.
- **`NntpArticle.Headers`** now exposes `NntpHeaderCollection` instead of `ImmutableDictionary<string, ImmutableList<string>>`. `NntpArticle.Equals` delegates header comparison to the collection. `PublicAPI.Unshipped.txt` updated (old getter marked `*REMOVED*`).
- **`ArticleResponseParser`** parses each header line once into a flat list of key/value pairs, folding continuation lines onto the previous pair in place, then wraps the list. This drops the per-line `Header` object, the `HashSet`-per-key `MultiValueDictionary`, and the `ToImmutableDictionary` + per-key `ToImmutableList` double build. Header-parse allocations are now roughly the count of header strings plus the backing list/array.
- **`NntpArticleBuilder`** keeps its mutable header store as a flat `List<KeyValuePair<string,string>>`; **`ArticleWriter`** iterates the flat pairs. `MultiValueDictionary` stays in place for the unrelated NZB code paths.

## Acceptance criteria

- [x] `NntpHeaderCollection` is order-preserving, case-insensitive, multi-valued.
- [x] `NntpArticle.Headers` exposes the new type; PublicAPI updated.
- [x] Header parsing allocates roughly the count of header strings, no per-key `HashSet` / immutable rebuild.
- [x] Folded (continuation) header lines parse correctly (covered by existing `Multi: line1 / line2 / line3` parser test).
- [x] Existing header/article tests pass; new `NntpHeaderCollectionTests` cover ordering, case-insensitive lookup, multi-value, equality.
- [x] `HeaderParseBenchmarks` (MemoryDiagnoser, includes a folded line) isolates the header-parse allocation for before/after comparison.

## Verification

- `dotnet csharpier check .` — clean
- `dotnet build --no-restore` (net8.0 + net10.0, `TreatWarningsAsErrors`, `AnalysisMode=All`) — clean
- `dotnet test --no-build` — 272 passed