### PR TITLE
Make article reads byte-oriented with pooled, caller-owned response

### DIFF
--- a/src/Usenet/Nntp/Contracts/INntpConnection.cs
+++ b/src/Usenet/Nntp/Contracts/INntpConnection.cs
@@ -127,6 +127,21 @@ public interface INntpConnection : IDisposable
     );
 
     /// <summary>
+    /// Sends a command to the usenet server asynchronously and materializes the multi-line data block
+    /// into a single contiguous, pooled byte buffer instead of decoding it into <see cref="string"/> lines.
+    /// </summary>
+    /// <typeparam name="TResponse">The type of the parsed response.</typeparam>
+    /// <param name="command">The command to send to the server.</param>
+    /// <param name="parser">The buffered multi-line response parser to use.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A response object of type <typeparamref name="TResponse"/>.</returns>
+    Task<TResponse> BufferedMultiLineCommandAsync<TResponse>(
+        string command,
+        IBufferedMultiLineResponseParser<TResponse> parser,
+        CancellationToken cancellationToken
+    );
+
+    /// <summary>
     /// Gets a single-line response from the usenet server asynchronously.
     /// </summary>
     /// <typeparam name="TResponse">The type of the parsed response.</typeparam>

--- a/src/Usenet/Nntp/NntpClient.cs
+++ b/src/Usenet/Nntp/NntpClient.cs
@@ -200,7 +200,7 @@ public partial class NntpClient : INntpClient
         NntpMessageId messageId,
         CancellationToken cancellationToken
     ) =>
-        Connection.MultiLineCommandAsync(
+        Connection.BufferedMultiLineCommandAsync(
             $"ARTICLE {messageId.ThrowIfNullOrWhiteSpace(nameof(messageId))}",
             new ArticleResponseParser(ArticleRequestType.Article, _loggerFactory),
             cancellationToken
@@ -211,7 +211,7 @@ public partial class NntpClient : INntpClient
         long number,
         CancellationToken cancellationToken
     ) =>
-        Connection.MultiLineCommandAsync(
+        Connection.BufferedMultiLineCommandAsync(
             $"ARTICLE {number}",
             new ArticleResponseParser(ArticleRequestType.Article, _loggerFactory),
             cancellationToken
@@ -219,7 +219,7 @@ public partial class NntpClient : INntpClient
 
     /// <inheritdoc />
     public Task<NntpArticleResponse> ArticleAsync(CancellationToken cancellationToken) =>
-        Connection.MultiLineCommandAsync(
+        Connection.BufferedMultiLineCommandAsync(
             "ARTICLE",
             new ArticleResponseParser(ArticleRequestType.Article, _loggerFactory),
             cancellationToken
@@ -230,7 +230,7 @@ public partial class NntpClient : INntpClient
         NntpMessageId messageId,
         CancellationToken cancellationToken
     ) =>
-        Connection.MultiLineCommandAsync(
+        Connection.BufferedMultiLineCommandAsync(
             $"HEAD {messageId.ThrowIfNullOrWhiteSpace(nameof(messageId))}",
             new ArticleResponseParser(ArticleRequestType.Head, _loggerFactory),
             cancellationToken
@@ -238,7 +238,7 @@ public partial class NntpClient : INntpClient
 
     /// <inheritdoc />
     public Task<NntpArticleResponse> HeadAsync(long number, CancellationToken cancellationToken) =>
-        Connection.MultiLineCommandAsync(
+        Connection.BufferedMultiLineCommandAsync(
             $"HEAD {number}",
             new ArticleResponseParser(ArticleRequestType.Head, _loggerFactory),
             cancellationToken
@@ -246,7 +246,7 @@ public partial class NntpClient : INntpClient
 
     /// <inheritdoc />
     public Task<NntpArticleResponse> HeadAsync(CancellationToken cancellationToken) =>
-        Connection.MultiLineCommandAsync(
+        Connection.BufferedMultiLineCommandAsync(
             "HEAD",
             new ArticleResponseParser(ArticleRequestType.Head, _loggerFactory),
             cancellationToken
@@ -257,7 +257,7 @@ public partial class NntpClient : INntpClient
         NntpMessageId messageId,
         CancellationToken cancellationToken
     ) =>
-        Connection.MultiLineCommandAsync(
+        Connection.BufferedMultiLineCommandAsync(
             $"BODY {messageId.ThrowIfNullOrWhiteSpace(nameof(messageId))}",
             new ArticleResponseParser(ArticleRequestType.Body, _loggerFactory),
             cancellationToken
@@ -265,7 +265,7 @@ public partial class NntpClient : INntpClient
 
     /// <inheritdoc />
     public Task<NntpArticleResponse> BodyAsync(long number, CancellationToken cancellationToken) =>
-        Connection.MultiLineCommandAsync(
+        Connection.BufferedMultiLineCommandAsync(
             $"BODY {number}",
             new ArticleResponseParser(ArticleRequestType.Body, _loggerFactory),
             cancellationToken
@@ -273,7 +273,7 @@ public partial class NntpClient : INntpClient
 
     /// <inheritdoc />
     public Task<NntpArticleResponse> BodyAsync(CancellationToken cancellationToken) =>
-        Connection.MultiLineCommandAsync(
+        Connection.BufferedMultiLineCommandAsync(
             "BODY",
             new ArticleResponseParser(ArticleRequestType.Body, _loggerFactory),
             cancellationToken

--- a/src/Usenet/Nntp/NntpConnection.cs
+++ b/src/Usenet/Nntp/NntpConnection.cs
@@ -27,6 +27,7 @@ namespace Usenet.Nntp;
 public sealed partial class NntpConnection : INntpConnection, INntpStreamSource
 {
     private const int StackAllocThreshold = 256;
+    private const int InitialDataBlockBufferSize = 4096;
     private const string AuthInfoPass = "AUTHINFO PASS";
 
     private readonly ILogger _log;
@@ -181,6 +182,39 @@ public sealed partial class NntpConnection : INntpConnection, INntpStreamSource
     internal bool HasPendingStream => _streaming;
 
     /// <inheritdoc/>
+    public async Task<TResponse> BufferedMultiLineCommandAsync<TResponse>(
+        string command,
+        IBufferedMultiLineResponseParser<TResponse> parser,
+        CancellationToken cancellationToken
+    )
+    {
+        ThrowIfNotConnected();
+        ArgumentNullException.ThrowIfNull(parser);
+
+        var response = await CommandAsync(command, new ResponseParser(), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!parser.IsSuccessResponse(response.Code))
+        {
+            return parser.ParseError(response.Code, response.Message);
+        }
+
+        var (buffer, length) = await ReadDataBlockToBufferAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        try
+        {
+            // The parser takes ownership of the pooled buffer on the success path.
+            return parser.Parse(response.Code, response.Message, buffer, length);
+        }
+        catch
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task<TResponse> GetResponseAsync<TResponse>(
         IResponseParser<TResponse> parser,
         CancellationToken cancellationToken
@@ -257,6 +291,148 @@ public sealed partial class NntpConnection : INntpConnection, INntpStreamSource
 
             yield return processed;
         }
+    }
+
+    /// <summary>
+    /// Reads a complete multi-line data block off the byte stream into a single contiguous buffer
+    /// rented from <see cref="ArrayPool{T}"/>. Dot-stuffing is undone and the terminating dot is
+    /// detected on the raw bytes, without transcoding the body to <see cref="string"/>. Each line is
+    /// stored with a normalized CRLF terminator. The caller takes ownership of the returned buffer.
+    /// </summary>
+    private async Task<(byte[] Buffer, int Length)> ReadDataBlockToBufferAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(InitialDataBlockBufferSize);
+        var length = 0;
+        try
+        {
+            while (true)
+            {
+                var result = await _reader!.ReadAsync(cancellationToken).ConfigureAwait(false);
+                var segment = result.Buffer;
+
+                var consumed = AppendLines(segment, ref buffer, ref length, out var completed);
+                AddBytesRead(consumed);
+                var consumedPosition = segment.GetPosition(consumed);
+
+                if (completed || result.IsCompleted)
+                {
+                    _reader.AdvanceTo(consumedPosition);
+                    return (buffer, length);
+                }
+
+                _reader.AdvanceTo(consumedPosition, segment.End);
+            }
+        }
+        catch
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            throw;
+        }
+    }
+
+    private static long AppendLines(
+        in ReadOnlySequence<byte> segment,
+        ref byte[] buffer,
+        ref int length,
+        out bool completed
+    )
+    {
+        completed = false;
+        var reader = new SequenceReader<byte>(segment);
+        while (
+            reader.TryReadTo(
+                out ReadOnlySequence<byte> lineSequence,
+                (byte)'\n',
+                advancePastDelimiter: true
+            )
+        )
+        {
+            if (AppendLine(lineSequence, ref buffer, ref length))
+            {
+                completed = true;
+                break;
+            }
+        }
+
+        return reader.Consumed;
+    }
+
+    /// <summary>
+    /// Appends a single framed line to the data block buffer, returning <see langword="true"/> when the
+    /// line is the terminating dot of the data block.
+    /// </summary>
+    private static bool AppendLine(
+        in ReadOnlySequence<byte> lineSequence,
+        ref byte[] buffer,
+        ref int length
+    )
+    {
+        if (lineSequence.IsSingleSegment)
+        {
+            return AppendLine(lineSequence.FirstSpan, ref buffer, ref length);
+        }
+
+        var lineLength = (int)lineSequence.Length;
+        byte[]? rented = null;
+        var line =
+            lineLength <= StackAllocThreshold
+                ? stackalloc byte[StackAllocThreshold]
+                : (rented = ArrayPool<byte>.Shared.Rent(lineLength));
+        try
+        {
+            lineSequence.CopyTo(line);
+            return AppendLine(line[..lineLength], ref buffer, ref length);
+        }
+        finally
+        {
+            if (rented != null)
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
+
+    private static bool AppendLine(ReadOnlySpan<byte> line, ref byte[] buffer, ref int length)
+    {
+        // Strip the trailing CR of the CRLF terminator.
+        if (line.Length > 0 && line[^1] == (byte)'\r')
+        {
+            line = line[..^1];
+        }
+
+        // A line containing only "." terminates the data block.
+        if (line.Length == 1 && line[0] == (byte)'.')
+        {
+            return true;
+        }
+
+        // Undo dot-stuffing of a line that begins with ".".
+        if (line.Length > 0 && line[0] == (byte)'.')
+        {
+            line = line[1..];
+        }
+
+        EnsureCapacity(ref buffer, length, length + line.Length + 2);
+        line.CopyTo(buffer.AsSpan(length));
+        length += line.Length;
+        buffer[length++] = (byte)'\r';
+        buffer[length++] = (byte)'\n';
+        return false;
+    }
+
+    private static void EnsureCapacity(ref byte[] buffer, int length, int required)
+    {
+        if (buffer.Length >= required)
+        {
+            return;
+        }
+
+        var next = ArrayPool<byte>.Shared.Rent(Math.Max(buffer.Length * 2, required));
+        buffer.AsSpan(0, length).CopyTo(next);
+        ArrayPool<byte>.Shared.Return(buffer);
+        buffer = next;
     }
 
     /// <summary>

--- a/src/Usenet/Nntp/Parsers/ArticleResponseParser.cs
+++ b/src/Usenet/Nntp/Parsers/ArticleResponseParser.cs
@@ -1,10 +1,10 @@
-using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Usenet.Extensions;
 using Usenet.Nntp.Builders;
 using Usenet.Nntp.Models;
 using Usenet.Nntp.Responses;
+using Usenet.Util;
 
 namespace Usenet.Nntp.Parsers;
 
@@ -46,25 +46,20 @@ internal sealed class ArticleResponseParser : IBufferedMultiLineResponseParser<N
         var (number, messageId) = ParseResponseLine(message);
 
         var bodyOffset = length;
-        var headers = ImmutableDictionary<string, ImmutableList<string>>.Empty.WithComparers(
-            StringComparer.OrdinalIgnoreCase
-        );
+        var headers = NntpHeaderCollection.Empty;
         var groups = NntpGroups.Empty;
 
         // The headers and the empty line separating them from the body are decoded as text; the body
         // bytes are left untouched in the pooled buffer (see ADR-0002).
         if ((_requestType & ArticleRequestType.Head) == ArticleRequestType.Head)
         {
-            var parsed = ParseHeaders(buffer.AsSpan(0, length), out bodyOffset);
-            headers = parsed.ToImmutableDictionary(
-                x => x.Key,
-                x => x.Value.ToImmutableList(),
-                keyComparer: StringComparer.OrdinalIgnoreCase
-            );
+            headers = ParseHeaders(buffer.AsSpan(0, length), out bodyOffset);
 
-            if (parsed.TryGetValue(NntpHeaders.Newsgroups, out var values))
+            if (headers.Contains(NntpHeaders.Newsgroups))
             {
-                groups = new NntpGroupsBuilder().Add(values).Build();
+                groups = new NntpGroupsBuilder()
+                    .Add(headers.GetValues(NntpHeaders.Newsgroups))
+                    .Build();
             }
         }
         else
@@ -99,13 +94,11 @@ internal sealed class ArticleResponseParser : IBufferedMultiLineResponseParser<N
         return (number, messageId);
     }
 
-    private MultiValueDictionary<string, string> ParseHeaders(
-        ReadOnlySpan<byte> span,
-        out int bodyOffset
-    )
+    private NntpHeaderCollection ParseHeaders(ReadOnlySpan<byte> span, out int bodyOffset)
     {
-        var headers = new List<Header>();
-        Header? prevHeader = null;
+        // Parse each header line once into a flat list of key/value pairs, preserving order.
+        // Folded continuation lines are appended onto the previous pair's value in place.
+        var headers = new List<KeyValuePair<string, string>>();
         var position = 0;
         bodyOffset = span.Length;
 
@@ -129,7 +122,7 @@ internal sealed class ArticleResponseParser : IBufferedMultiLineResponseParser<N
             }
 
             var line = UsenetEncoding.Default.GetString(span[position..contentEnd]);
-            if (char.IsWhiteSpace(line[0]) && prevHeader != null)
+            if (char.IsWhiteSpace(line[0]) && headers.Count > 0)
             {
                 var previous = headers[^1];
                 headers[^1] = new KeyValuePair<string, string>(
@@ -154,17 +147,5 @@ internal sealed class ArticleResponseParser : IBufferedMultiLineResponseParser<N
         }
 
         return headers.Count == 0 ? NntpHeaderCollection.Empty : new NntpHeaderCollection(headers);
-    }
-
-    private sealed class Header
-    {
-        public string Key { get; }
-        public string Value { get; set; }
-
-        public Header(string key, string value)
-        {
-            Key = key;
-            Value = value;
-        }
     }
 }

--- a/src/Usenet/Nntp/Parsers/ArticleResponseParser.cs
+++ b/src/Usenet/Nntp/Parsers/ArticleResponseParser.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Usenet.Extensions;
@@ -15,7 +16,7 @@ internal enum ArticleRequestType
     Article = 0x03,
 }
 
-internal class ArticleResponseParser : IMultiLineResponseParser<NntpArticleResponse>
+internal sealed class ArticleResponseParser : IBufferedMultiLineResponseParser<NntpArticleResponse>
 {
     private readonly ILogger _log;
     private readonly ArticleRequestType _requestType;
@@ -38,14 +39,55 @@ internal class ArticleResponseParser : IMultiLineResponseParser<NntpArticleRespo
 
     public bool IsSuccessResponse(int code) => code == _successCode;
 
-    public NntpArticleResponse Parse(int code, string message, IEnumerable<string> dataBlock)
+    public NntpArticleResponse ParseError(int code, string message) => new(code, message, false);
+
+    public NntpArticleResponse Parse(int code, string message, byte[] buffer, int length)
     {
-        if (!IsSuccessResponse(code))
+        var (number, messageId) = ParseResponseLine(message);
+
+        var bodyOffset = length;
+        var headers = ImmutableDictionary<string, ImmutableList<string>>.Empty.WithComparers(
+            StringComparer.OrdinalIgnoreCase
+        );
+        var groups = NntpGroups.Empty;
+
+        // The headers and the empty line separating them from the body are decoded as text; the body
+        // bytes are left untouched in the pooled buffer (see ADR-0002).
+        if ((_requestType & ArticleRequestType.Head) == ArticleRequestType.Head)
         {
-            return new NntpArticleResponse(code, message, false, null);
+            var parsed = ParseHeaders(buffer.AsSpan(0, length), out bodyOffset);
+            headers = parsed.ToImmutableDictionary(
+                x => x.Key,
+                x => x.Value.ToImmutableList(),
+                keyComparer: StringComparer.OrdinalIgnoreCase
+            );
+
+            if (parsed.TryGetValue(NntpHeaders.Newsgroups, out var values))
+            {
+                groups = new NntpGroupsBuilder().Add(values).Build();
+            }
+        }
+        else
+        {
+            // A BODY response is body bytes only.
+            bodyOffset = 0;
         }
 
-        // get response line
+        return new NntpArticleResponse(
+            code,
+            message,
+            number,
+            messageId,
+            groups,
+            headers,
+            buffer,
+            bodyOffset,
+            length
+        );
+    }
+
+    private (long Number, NntpMessageId MessageId) ParseResponseLine(string message)
+    {
         var responseSplit = message.Split(' ');
         if (responseSplit.Length < 2)
         {
@@ -54,49 +96,40 @@ internal class ArticleResponseParser : IMultiLineResponseParser<NntpArticleRespo
 
         _ = long.TryParse(responseSplit.Length > 0 ? responseSplit[0] : null, out var number);
         NntpMessageId messageId = responseSplit.Length > 1 ? responseSplit[1] : NntpMessageId.Empty;
-
-        using var enumerator = dataBlock.GetEnumerator();
-
-        // get headers if requested
-        var headers =
-            (_requestType & ArticleRequestType.Head) == ArticleRequestType.Head
-                ? GetHeaders(enumerator)
-                : NntpHeaderCollection.Empty;
-
-        // get groups
-        var groups = headers.Contains(NntpHeaders.Newsgroups)
-            ? new NntpGroupsBuilder().Add(headers.GetValues(NntpHeaders.Newsgroups)).Build()
-            : NntpGroups.Empty;
-
-        // get body if requested
-        var bodyLines =
-            (_requestType & ArticleRequestType.Body) == ArticleRequestType.Body
-                ? GetBody(enumerator).ToList()
-                : [];
-
-        return new NntpArticleResponse(
-            code,
-            message,
-            true,
-            new NntpArticle(number, messageId, groups, headers, bodyLines)
-        );
+        return (number, messageId);
     }
 
-    private NntpHeaderCollection GetHeaders(IEnumerator<string> enumerator)
+    private MultiValueDictionary<string, string> ParseHeaders(
+        ReadOnlySpan<byte> span,
+        out int bodyOffset
+    )
     {
-        // Parse each header line once into a flat list of key/value pairs, preserving order.
-        // Folded continuation lines are appended onto the previous pair's value in place.
-        var headers = new List<KeyValuePair<string, string>>();
-        while (enumerator.MoveNext())
+        var headers = new List<Header>();
+        Header? prevHeader = null;
+        var position = 0;
+        bodyOffset = span.Length;
+
+        while (position < span.Length)
         {
-            var line = enumerator.Current;
-            if (string.IsNullOrEmpty(line))
+            var newline = span[position..].IndexOf((byte)'\n');
+            var lineEnd = newline < 0 ? span.Length : position + newline;
+            var next = newline < 0 ? span.Length : lineEnd + 1;
+
+            var contentEnd = lineEnd;
+            if (contentEnd > position && span[contentEnd - 1] == (byte)'\r')
             {
-                // no more headers (skip empty line)
+                contentEnd--;
+            }
+
+            if (contentEnd == position)
+            {
+                // The empty line separates the headers from the body.
+                bodyOffset = next;
                 break;
             }
 
-            if (char.IsWhiteSpace(line[0]) && headers.Count > 0)
+            var line = UsenetEncoding.Default.GetString(span[position..contentEnd]);
+            if (char.IsWhiteSpace(line[0]) && prevHeader != null)
             {
                 var previous = headers[^1];
                 headers[^1] = new KeyValuePair<string, string>(
@@ -116,17 +149,22 @@ internal class ArticleResponseParser : IMultiLineResponseParser<NntpArticleRespo
                     headers.Add(new(line[..splitPos], line[(splitPos + 1)..].Trim()));
                 }
             }
+
+            position = next;
         }
 
         return headers.Count == 0 ? NntpHeaderCollection.Empty : new NntpHeaderCollection(headers);
     }
 
-    private static IEnumerable<string> GetBody(IEnumerator<string> enumerator)
+    private sealed class Header
     {
-        while (enumerator.MoveNext())
+        public string Key { get; }
+        public string Value { get; set; }
+
+        public Header(string key, string value)
         {
-            if (enumerator.Current is not null)
-                yield return enumerator.Current;
+            Key = key;
+            Value = value;
         }
     }
 }

--- a/src/Usenet/Nntp/Parsers/IBufferedMultiLineResponseParser.cs
+++ b/src/Usenet/Nntp/Parsers/IBufferedMultiLineResponseParser.cs
@@ -1,0 +1,40 @@
+using JetBrains.Annotations;
+
+namespace Usenet.Nntp.Parsers;
+
+/// <summary>
+/// Represents a parser for a multi-line response whose data block is materialized into a single
+/// contiguous, pooled byte buffer instead of a sequence of decoded <see cref="string"/> lines.
+/// The parser takes ownership of the pooled buffer on the success path; the response it produces
+/// is responsible for returning the buffer to the pool when it is disposed.
+/// </summary>
+/// <typeparam name="TResponse">The type of the parsed response.</typeparam>
+[PublicAPI]
+public interface IBufferedMultiLineResponseParser<out TResponse>
+{
+    /// <summary>
+    /// Determines if the received response code is valid.
+    /// </summary>
+    /// <param name="code">The response code received from the server.</param>
+    /// <returns>true if <paramref name="code"/> is valid; otherwise false.</returns>
+    bool IsSuccessResponse(int code);
+
+    /// <summary>
+    /// Parses a failure response that carries no data block.
+    /// </summary>
+    /// <param name="code">The response code received from the server.</param>
+    /// <param name="message">The response message received from the server.</param>
+    /// <returns>A new instance of type <typeparamref name="TResponse"/>.</returns>
+    TResponse ParseError(int code, string message);
+
+    /// <summary>
+    /// Parses the multi-line data block of a successful response. The implementation takes
+    /// ownership of <paramref name="buffer"/> and is responsible for returning it to the pool.
+    /// </summary>
+    /// <param name="code">The response code received from the server.</param>
+    /// <param name="message">The response message received from the server.</param>
+    /// <param name="buffer">The pooled buffer holding the materialized data block.</param>
+    /// <param name="length">The number of valid bytes in <paramref name="buffer"/>.</param>
+    /// <returns>A new instance of type <typeparamref name="TResponse"/>.</returns>
+    TResponse Parse(int code, string message, byte[] buffer, int length);
+}

--- a/src/Usenet/Nntp/Responses/NntpArticleResponse.cs
+++ b/src/Usenet/Nntp/Responses/NntpArticleResponse.cs
@@ -1,5 +1,4 @@
 using System.Buffers;
-using System.Collections.Immutable;
 using System.Text;
 using JetBrains.Annotations;
 using Usenet.Nntp.Models;
@@ -53,9 +52,9 @@ public sealed class NntpArticleResponse : NntpResponse, IDisposable, IAsyncDispo
     public NntpGroups Groups { get; }
 
     /// <summary>
-    /// The header dictionary of the article. Empty for a <c>BODY</c> response or a failure response.
+    /// The headers of the article. Empty for a <c>BODY</c> response or a failure response.
     /// </summary>
-    public ImmutableDictionary<string, ImmutableList<string>> Headers { get; }
+    public NntpHeaderCollection Headers { get; }
 
     /// <summary>
     /// The article body as the raw bytes transmitted by the server, with dot-stuffing undone and the
@@ -79,9 +78,7 @@ public sealed class NntpArticleResponse : NntpResponse, IDisposable, IAsyncDispo
     internal NntpArticleResponse(int code, string message, bool success)
         : base(code, message, success)
     {
-        Headers = ImmutableDictionary<string, ImmutableList<string>>.Empty.WithComparers(
-            StringComparer.OrdinalIgnoreCase
-        );
+        Headers = NntpHeaderCollection.Empty;
         MessageId = NntpMessageId.Empty;
         Groups = NntpGroups.Empty;
 
@@ -99,7 +96,7 @@ public sealed class NntpArticleResponse : NntpResponse, IDisposable, IAsyncDispo
         long number,
         NntpMessageId messageId,
         NntpGroups groups,
-        ImmutableDictionary<string, ImmutableList<string>> headers,
+        NntpHeaderCollection headers,
         byte[] buffer,
         int bodyOffset,
         int length

--- a/src/Usenet/Nntp/Responses/NntpArticleResponse.cs
+++ b/src/Usenet/Nntp/Responses/NntpArticleResponse.cs
@@ -1,5 +1,9 @@
-﻿using JetBrains.Annotations;
+using System.Buffers;
+using System.Collections.Immutable;
+using System.Text;
+using JetBrains.Annotations;
 using Usenet.Nntp.Models;
+using Usenet.Util;
 
 namespace Usenet.Nntp.Responses;
 
@@ -9,24 +13,202 @@ namespace Usenet.Nntp.Responses;
 /// <a href="https://tools.ietf.org/html/rfc3977#section-6.2.2">HEAD</a> and
 /// <a href="https://tools.ietf.org/html/rfc3977#section-6.2.3">BODY</a> commands.
 /// </summary>
+/// <remarks>
+/// The article is buffered whole (one article, bounded around 1 MB) into a single contiguous
+/// buffer rented from <see cref="ArrayPool{T}"/>. The response owns that buffer: the <see cref="Body"/>
+/// view and the lines returned by <see cref="ReadBodyLines()"/> are only valid until the response is
+/// disposed, after which the buffer is returned to the pool. Always dispose the response (preferably
+/// with <c>using</c>/<c>await using</c>); a forgotten response is recovered by a finalizer that returns
+/// the buffer and increments <see cref="LeakedBufferCount"/>.
+/// </remarks>
 [PublicAPI]
-public class NntpArticleResponse : NntpResponse
+public sealed class NntpArticleResponse : NntpResponse, IDisposable, IAsyncDisposable
 {
-    /// <summary>
-    /// The <see cref="NntpArticle"/> received from the server.
-    /// </summary>
-    public NntpArticle? Article { get; }
+    private static long _leakedBufferCount;
 
     /// <summary>
-    /// Creates a new instance of the <see cref="NntpArticleResponse"/> class.
+    /// The number of pooled buffers reclaimed by the finalizer because a response was not disposed.
+    /// A non-zero value is a diagnostic signal that a caller forgot to dispose an article response.
     /// </summary>
-    /// <param name="code">The response code received from the server.</param>
-    /// <param name="message">The response message received from the server.</param>
-    /// <param name="success">A value indicating whether the command succeeded or failed.</param>
-    /// <param name="article">The <see cref="NntpArticle"/> received from the server.</param>
-    internal NntpArticleResponse(int code, string message, bool success, NntpArticle? article)
+    public static long LeakedBufferCount => Interlocked.Read(ref _leakedBufferCount);
+
+    private byte[]? _buffer;
+    private readonly int _bodyOffset;
+    private readonly int _length;
+    private bool _disposed;
+
+    /// <summary>
+    /// The number of the article in the currently selected newsgroup.
+    /// </summary>
+    public long Number { get; }
+
+    /// <summary>
+    /// The message-id of the article.
+    /// </summary>
+    public NntpMessageId MessageId { get; }
+
+    /// <summary>
+    /// The NNTP newsgroups the article is posted in.
+    /// </summary>
+    public NntpGroups Groups { get; }
+
+    /// <summary>
+    /// The header dictionary of the article. Empty for a <c>BODY</c> response or a failure response.
+    /// </summary>
+    public ImmutableDictionary<string, ImmutableList<string>> Headers { get; }
+
+    /// <summary>
+    /// The article body as the raw bytes transmitted by the server, with dot-stuffing undone and the
+    /// terminating dot removed. The memory is backed by a pooled buffer and is only valid until this
+    /// response is disposed. Empty for a <c>HEAD</c> response or a failure response.
+    /// </summary>
+    public ReadOnlyMemory<byte> Body
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _buffer is null
+                ? ReadOnlyMemory<byte>.Empty
+                : _buffer.AsMemory(_bodyOffset, _length - _bodyOffset);
+        }
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="NntpArticleResponse"/> class for a failure response.
+    /// </summary>
+    internal NntpArticleResponse(int code, string message, bool success)
         : base(code, message, success)
     {
-        Article = article;
+        Headers = ImmutableDictionary<string, ImmutableList<string>>.Empty.WithComparers(
+            StringComparer.OrdinalIgnoreCase
+        );
+        MessageId = NntpMessageId.Empty;
+        Groups = NntpGroups.Empty;
+
+        // A failure response owns no pooled buffer, so it never needs finalization.
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="NntpArticleResponse"/> class for a successful response,
+    /// taking ownership of the pooled <paramref name="buffer"/>.
+    /// </summary>
+    internal NntpArticleResponse(
+        int code,
+        string message,
+        long number,
+        NntpMessageId messageId,
+        NntpGroups groups,
+        ImmutableDictionary<string, ImmutableList<string>> headers,
+        byte[] buffer,
+        int bodyOffset,
+        int length
+    )
+        : base(code, message, true)
+    {
+        Number = number;
+        MessageId = messageId;
+        Groups = groups;
+        Headers = headers;
+        _buffer = buffer;
+        _bodyOffset = bodyOffset;
+        _length = length;
+    }
+
+    /// <summary>
+    /// Reads the article body as text lines on demand, using the default Usenet character encoding.
+    /// Each line is decoded from the pooled buffer when enumerated; the result is only valid until
+    /// this response is disposed.
+    /// </summary>
+    /// <returns>The body lines, with their CRLF terminators stripped.</returns>
+    public IEnumerable<string> ReadBodyLines() => ReadBodyLines(UsenetEncoding.Default);
+
+    /// <summary>
+    /// Reads the article body as text lines on demand, using the specified character encoding.
+    /// Each line is decoded from the pooled buffer when enumerated; the result is only valid until
+    /// this response is disposed.
+    /// </summary>
+    /// <param name="encoding">The character encoding used to decode the body lines.</param>
+    /// <returns>The body lines, with their CRLF terminators stripped.</returns>
+    public IEnumerable<string> ReadBodyLines(Encoding encoding)
+    {
+        ArgumentNullException.ThrowIfNull(encoding);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var buffer = _buffer;
+        return buffer is null ? [] : EnumerateLines(buffer, _bodyOffset, _length, encoding);
+    }
+
+    private static IEnumerable<string> EnumerateLines(
+        byte[] buffer,
+        int offset,
+        int length,
+        Encoding encoding
+    )
+    {
+        var position = offset;
+        while (position < length)
+        {
+            var newline = Array.IndexOf(buffer, (byte)'\n', position, length - position);
+            var lineEnd = newline < 0 ? length : newline;
+            var next = newline < 0 ? length : newline + 1;
+
+            var contentEnd = lineEnd;
+            if (contentEnd > position && buffer[contentEnd - 1] == (byte)'\r')
+            {
+                contentEnd--;
+            }
+
+            yield return encoding.GetString(buffer, position, contentEnd - position);
+            position = next;
+        }
+    }
+
+    /// <summary>
+    /// Returns the pooled buffer to the <see cref="ArrayPool{T}"/> it was rented from. After disposal
+    /// the <see cref="Body"/> view and any in-flight <see cref="ReadBodyLines()"/> enumeration are no
+    /// longer valid.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        var buffer = _buffer;
+        _buffer = null;
+        if (buffer is not null)
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    /// <inheritdoc cref="Dispose"/>
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        GC.SuppressFinalize(this);
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Safety net for a response that was never disposed: returns the pooled buffer and increments
+    /// <see cref="LeakedBufferCount"/> so a forgotten response cannot permanently starve the pool.
+    /// </summary>
+    ~NntpArticleResponse()
+    {
+        var buffer = _buffer;
+        if (buffer is null)
+        {
+            return;
+        }
+
+        _buffer = null;
+        ArrayPool<byte>.Shared.Return(buffer);
+        Interlocked.Increment(ref _leakedBufferCount);
     }
 }

--- a/src/Usenet/PublicAPI.Unshipped.txt
+++ b/src/Usenet/PublicAPI.Unshipped.txt
@@ -42,6 +42,23 @@ Usenet.Nntp.Contracts.INntpConnection.ResetCounters() -> void
 Usenet.Nntp.NntpConnection.BytesRead.get -> long
 Usenet.Nntp.NntpConnection.BytesWritten.get -> long
 Usenet.Nntp.NntpConnection.ResetCounters() -> void
+Usenet.Nntp.Parsers.IBufferedMultiLineResponseParser<TResponse>
+Usenet.Nntp.Parsers.IBufferedMultiLineResponseParser<TResponse>.IsSuccessResponse(int code) -> bool
+Usenet.Nntp.Parsers.IBufferedMultiLineResponseParser<TResponse>.Parse(int code, string! message, byte[]! buffer, int length) -> TResponse
+Usenet.Nntp.Parsers.IBufferedMultiLineResponseParser<TResponse>.ParseError(int code, string! message) -> TResponse
+Usenet.Nntp.Contracts.INntpConnection.BufferedMultiLineCommandAsync<TResponse>(string! command, Usenet.Nntp.Parsers.IBufferedMultiLineResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResponse>!
+Usenet.Nntp.NntpConnection.BufferedMultiLineCommandAsync<TResponse>(string! command, Usenet.Nntp.Parsers.IBufferedMultiLineResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<TResponse>!
+*REMOVED*Usenet.Nntp.Responses.NntpArticleResponse.Article.get -> Usenet.Nntp.Models.NntpArticle?
+Usenet.Nntp.Responses.NntpArticleResponse.Body.get -> System.ReadOnlyMemory<byte>
+Usenet.Nntp.Responses.NntpArticleResponse.Dispose() -> void
+Usenet.Nntp.Responses.NntpArticleResponse.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Usenet.Nntp.Responses.NntpArticleResponse.Groups.get -> Usenet.Nntp.Models.NntpGroups!
+Usenet.Nntp.Responses.NntpArticleResponse.Headers.get -> System.Collections.Immutable.ImmutableDictionary<string!, System.Collections.Immutable.ImmutableList<string!>!>!
+Usenet.Nntp.Responses.NntpArticleResponse.MessageId.get -> Usenet.Nntp.Models.NntpMessageId!
+Usenet.Nntp.Responses.NntpArticleResponse.Number.get -> long
+Usenet.Nntp.Responses.NntpArticleResponse.ReadBodyLines() -> System.Collections.Generic.IEnumerable<string!>!
+Usenet.Nntp.Responses.NntpArticleResponse.ReadBodyLines(System.Text.Encoding! encoding) -> System.Collections.Generic.IEnumerable<string!>!
+static Usenet.Nntp.Responses.NntpArticleResponse.LeakedBufferCount.get -> long
 *REMOVED*Usenet.Nntp.Contracts.INntpConnection.Stream.get -> Usenet.Util.CountingStream?
 *REMOVED*Usenet.Nntp.NntpConnection.Stream.get -> Usenet.Util.CountingStream?
 *REMOVED*Usenet.Util.CountingStream

--- a/src/Usenet/PublicAPI.Unshipped.txt
+++ b/src/Usenet/PublicAPI.Unshipped.txt
@@ -53,7 +53,7 @@ Usenet.Nntp.Responses.NntpArticleResponse.Body.get -> System.ReadOnlyMemory<byte
 Usenet.Nntp.Responses.NntpArticleResponse.Dispose() -> void
 Usenet.Nntp.Responses.NntpArticleResponse.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Usenet.Nntp.Responses.NntpArticleResponse.Groups.get -> Usenet.Nntp.Models.NntpGroups!
-Usenet.Nntp.Responses.NntpArticleResponse.Headers.get -> System.Collections.Immutable.ImmutableDictionary<string!, System.Collections.Immutable.ImmutableList<string!>!>!
+Usenet.Nntp.Responses.NntpArticleResponse.Headers.get -> Usenet.Nntp.Models.NntpHeaderCollection!
 Usenet.Nntp.Responses.NntpArticleResponse.MessageId.get -> Usenet.Nntp.Models.NntpMessageId!
 Usenet.Nntp.Responses.NntpArticleResponse.Number.get -> long
 Usenet.Nntp.Responses.NntpArticleResponse.ReadBodyLines() -> System.Collections.Generic.IEnumerable<string!>!

--- a/tests/Usenet.Benchmarks/Nntp/Client/NntpBenchmarks.cs
+++ b/tests/Usenet.Benchmarks/Nntp/Client/NntpBenchmarks.cs
@@ -41,8 +41,8 @@ public class NntpBenchmarks
     [Benchmark]
     public async Task<int> ArticleRead()
     {
-        var response = await _client.ArticleAsync(123);
-        return response.Article?.Body.Count ?? 0;
+        using var response = await _client.ArticleAsync(123);
+        return response.Body.Length;
     }
 
     [Benchmark]

--- a/tests/Usenet.Benchmarks/Nntp/Parsers/HeaderParseBenchmarks.cs
+++ b/tests/Usenet.Benchmarks/Nntp/Parsers/HeaderParseBenchmarks.cs
@@ -1,13 +1,16 @@
+using System.Buffers;
 using BenchmarkDotNet.Attributes;
 using Usenet.Nntp.Parsers;
-using Usenet.Nntp.Responses;
+using Usenet.Util;
 
 namespace Usenet.Benchmarks.Nntp.Parsers;
 
 /// <summary>
 /// Benchmarks parsing of a single NNTP article header block (as returned by
 /// <c>HEAD</c>). This isolates the header-folding and dictionary-building cost
-/// from any network I/O.
+/// from any network I/O. The header block is supplied as the contiguous,
+/// CRLF-terminated byte buffer the connection materializes for the byte-oriented
+/// read path.
 /// </summary>
 [MemoryDiagnoser]
 public class HeaderParseBenchmarks
@@ -15,11 +18,14 @@ public class HeaderParseBenchmarks
     private const string Message = "123 <message-id@benchmark> head";
 
     private readonly ArticleResponseParser _parser = new(ArticleRequestType.Head);
-    private List<string> _headerBlock = [];
+    private byte[] _buffer = [];
+    private int _length;
 
     [GlobalSetup]
-    public void Setup() =>
-        _headerBlock = [
+    public void Setup()
+    {
+        string[] headerLines =
+        [
             "Path: news.example.com!not-for-mail",
             "From: \"Benchmark Poster\" <poster@example.com>",
             "Newsgroups: alt.binaries.benchmark,alt.binaries.test",
@@ -35,6 +41,18 @@ public class HeaderParseBenchmarks
             "\tpart-two-folded",
         ];
 
+        _buffer = UsenetEncoding.Default.GetBytes(string.Join("\r\n", headerLines) + "\r\n");
+        _length = _buffer.Length;
+    }
+
     [Benchmark]
-    public NntpArticleResponse ParseHeaders() => _parser.Parse(221, Message, _headerBlock);
+    public int ParseHeaders()
+    {
+        // The parser takes ownership of the buffer, so hand it a fresh pooled copy each iteration and
+        // dispose the response to return that copy to the pool.
+        var buffer = ArrayPool<byte>.Shared.Rent(_length);
+        _buffer.AsSpan(0, _length).CopyTo(buffer);
+        using var response = _parser.Parse(221, Message, buffer, _length);
+        return response.Headers.Count;
+    }
 }

--- a/tests/Usenet.Tests/Nntp/NntpConnectionTests.cs
+++ b/tests/Usenet.Tests/Nntp/NntpConnectionTests.cs
@@ -84,7 +84,7 @@ internal sealed class NntpConnectionTests
         );
 
         await Assert.That(response.Success).IsTrue();
-        await Assert.That(response.Headers["Subject"]).Contains("test");
+        await Assert.That(response.Headers.GetValues("Subject")).Contains("test");
         await Assert.That(response.ReadBodyLines()).IsEquivalentTo(ExpectedBodyLines);
     }
 

--- a/tests/Usenet.Tests/Nntp/NntpConnectionTests.cs
+++ b/tests/Usenet.Tests/Nntp/NntpConnectionTests.cs
@@ -59,6 +59,35 @@ internal sealed class NntpConnectionTests
         await Assert.That(lines).IsEquivalentTo(ExpectedDataBlock);
     }
 
+    private static readonly string[] ExpectedBodyLines = [".dot-stuffed line", "last body line"];
+
+    [Test]
+    public async Task ShouldBufferArticleBodyAsBytesAndUndoDotStuffing(
+        CancellationToken cancellationToken
+    )
+    {
+        await using var server = new ScriptedNntpServer();
+        using var connection = new NntpConnection();
+
+        await connection.ConnectAsync(
+            IPAddress.Loopback.ToString(),
+            server.Port,
+            false,
+            new ResponseParser(200),
+            cancellationToken
+        );
+
+        using var response = await connection.BufferedMultiLineCommandAsync(
+            "ARTICLE 1",
+            new ArticleResponseParser(ArticleRequestType.Article),
+            cancellationToken
+        );
+
+        await Assert.That(response.Success).IsTrue();
+        await Assert.That(response.Headers["Subject"]).Contains("test");
+        await Assert.That(response.ReadBodyLines()).IsEquivalentTo(ExpectedBodyLines);
+    }
+
     [Test]
     public async Task ShouldCountBytesReadAndWritten(CancellationToken cancellationToken)
     {

--- a/tests/Usenet.Tests/Nntp/Parsers/ArticleResponseParserAllocationTests.cs
+++ b/tests/Usenet.Tests/Nntp/Parsers/ArticleResponseParserAllocationTests.cs
@@ -1,12 +1,16 @@
+using System.Buffers;
 using Usenet.Nntp.Parsers;
 using Usenet.Tests.TestHelpers;
+using Usenet.Util;
 
 namespace Usenet.Tests.Nntp.Parsers;
 
 /// <summary>
 /// Allocation-regression guard for parsing a single article header block (as returned by
-/// <c>HEAD</c>). This isolates the header-folding and dictionary-building cost from any
+/// <c>HEAD</c>). This isolates the header-folding and collection-building cost from any
 /// network I/O, so a regression in the parse path shows up as extra per-parse allocation.
+/// The working buffer is rented from the pool (ADR-0002) and is not counted by the
+/// measurement, so the bytes measured are the per-parse object/string churn.
 /// </summary>
 internal sealed class ArticleResponseParserAllocationTests
 {
@@ -30,10 +34,12 @@ internal sealed class ArticleResponseParserAllocationTests
         "\tpart-two-folded",
     ];
 
-    // Parsing this twelve-line block allocates ~9.6 KB: the header records and folded-value
-    // strings, the backing dictionary and the article/groups objects. The ceiling sits ~50%
-    // above the measured cost for runtime variation while still tripping if the parse regresses
-    // (e.g. extra copies of the header block or repeated splits).
+    // Parsing this twelve-line block decodes each header line off the pooled buffer and folds the
+    // continuation onto its predecessor, producing the per-line key/value strings, the flat
+    // key/value list wrapped in an NntpHeaderCollection, the groups and the response object. The
+    // pooled working buffer is not counted (ADR-0002). The ceiling sits ~50% above the measured
+    // cost for runtime variation while still tripping if the parse regresses (e.g. extra copies of
+    // the header block or repeated splits).
     private const long MaxBytesPerParse = 14_336;
     private const int Iterations = 200;
 
@@ -42,8 +48,17 @@ internal sealed class ArticleResponseParserAllocationTests
     {
         var parser = new ArticleResponseParser(ArticleRequestType.Head);
 
+        // Build the contiguous, CRLF-terminated data block once; each parse copies it into a freshly
+        // rented buffer and the response returns that buffer to the pool when disposed.
+        var block = UsenetEncoding.Default.GetBytes(string.Join("\r\n", HeaderBlock) + "\r\n");
+
         var perParse = AllocationMeasurement.PerIteration(
-            () => parser.Parse(221, Message, HeaderBlock),
+            () =>
+            {
+                var buffer = ArrayPool<byte>.Shared.Rent(block.Length);
+                block.CopyTo(buffer, 0);
+                using var response = parser.Parse(221, Message, buffer, block.Length);
+            },
             Iterations
         );
 

--- a/tests/Usenet.Tests/Nntp/Parsers/ArticleResponseParserTests.cs
+++ b/tests/Usenet.Tests/Nntp/Parsers/ArticleResponseParserTests.cs
@@ -58,9 +58,11 @@ internal sealed class ArticleResponseParserTests
         await Assert.That(response.Number).IsEqualTo(123L);
         await Assert.That(response.MessageId.ToString()).IsEqualTo("<123@poster.com>");
         await Assert
-            .That(response.Headers["Path"])
+            .That(response.Headers.GetValues("Path"))
             .Contains("pathost!demo!whitehouse!not-for-mail");
-        await Assert.That(response.Headers["From"]).Contains("\"Demo User\" <nobody@example.net>");
+        await Assert
+            .That(response.Headers.GetValues("From"))
+            .Contains("\"Demo User\" <nobody@example.net>");
         await Assert.That(response.ReadBodyLines()).IsEquivalentTo(ArticleBodyLines);
     }
 
@@ -103,9 +105,9 @@ internal sealed class ArticleResponseParserTests
             length
         );
 
-        await Assert.That(response.Headers["Multi"]).Contains("line1 line2 line3");
+        await Assert.That(response.Headers.GetValues("Multi")).Contains("line1 line2 line3");
         await Assert
-            .That(response.Headers["Path"])
+            .That(response.Headers.GetValues("Path"))
             .Contains("pathost!demo!whitehouse!not-for-mail");
         await Assert.That(response.Body.Length).IsEqualTo(0);
         await Assert.That(response.ReadBodyLines()).IsEmpty();
@@ -124,9 +126,9 @@ internal sealed class ArticleResponseParserTests
             length
         );
 
-        await Assert.That(response.Headers.ContainsKey("Invalid header line")).IsFalse();
+        await Assert.That(response.Headers.Contains("Invalid header line")).IsFalse();
         await Assert
-            .That(response.Headers["Path"])
+            .That(response.Headers.GetValues("Path"))
             .Contains("pathost!demo!whitehouse!not-for-mail");
     }
 

--- a/tests/Usenet.Tests/Nntp/Parsers/ArticleResponseParserTests.cs
+++ b/tests/Usenet.Tests/Nntp/Parsers/ArticleResponseParserTests.cs
@@ -1,189 +1,174 @@
-﻿using System.Text;
-using Usenet.Nntp.Models;
+using System.Buffers;
 using Usenet.Nntp.Parsers;
+using Usenet.Util;
 
 namespace Usenet.Tests.Nntp.Parsers;
 
 internal sealed class ArticleResponseParserTests
 {
-    public static IEnumerable<Func<(int, string, int, string[], NntpArticle)>> MultiLineParseData()
+    private static readonly string[] ArticleBodyLines =
+    [
+        "This is just a test article (1).",
+        "With two lines.",
+    ];
+
+    private static readonly string[] BodyLines =
+    [
+        "This is just a test article (2).",
+        "With two lines.",
+    ];
+
+    /// <summary>
+    /// Builds the contiguous, CRLF-terminated, pool-rented byte buffer the connection materializes for
+    /// the byte-oriented read path (dot-stuffing already undone, terminating dot already removed). The
+    /// parser takes ownership and the response returns the buffer to the pool when disposed.
+    /// </summary>
+    private static (byte[] Buffer, int Length) BuildDataBlock(string[] lines)
     {
-        yield return () =>
-            (
-                220,
-                "123 <123@poster.com>",
-                (int)ArticleRequestType.Article,
-                [],
-                new NntpArticle(
-                    123,
-                    "<123@poster.com>",
-                    NntpGroups.Empty,
-                    NntpHeaderCollection.Empty,
-                    new List<string>(0)
-                )
-            );
-
-        yield return () =>
-            (
-                220,
-                "123 <123@poster.com>",
-                (int)ArticleRequestType.Article,
-                [
-                    "Path: pathost!demo!whitehouse!not-for-mail",
-                    "From: \"Demo User\" <nobody@example.net>",
-                    "",
-                    "This is just a test article (1).",
-                    "With two lines.",
-                ],
-                new NntpArticle(
-                    123,
-                    "<123@poster.com>",
-                    NntpGroups.Empty,
-                    new NntpHeaderCollection([
-                        new("Path", "pathost!demo!whitehouse!not-for-mail"),
-                        new("From", "\"Demo User\" <nobody@example.net>"),
-                    ]),
-                    new List<string> { "This is just a test article (1).", "With two lines." }
-                )
-            );
-
-        yield return () =>
-            (
-                222,
-                "123 <123@poster.com>",
-                (int)ArticleRequestType.Body,
-                ["This is just a test article (2).", "With two lines."],
-                new NntpArticle(
-                    123,
-                    "<123@poster.com>",
-                    NntpGroups.Empty,
-                    NntpHeaderCollection.Empty,
-                    new List<string> { "This is just a test article (2).", "With two lines." }
-                )
-            );
-
-        yield return () =>
-            (
-                221,
-                "123 <123@poster.com>",
-                (int)ArticleRequestType.Head,
-                ["Multi: line1", " line2", " line3", "Path: pathost!demo!whitehouse!not-for-mail"],
-                new NntpArticle(
-                    123,
-                    "<123@poster.com>",
-                    NntpGroups.Empty,
-                    new NntpHeaderCollection([
-                        new("Multi", "line1 line2 line3"),
-                        new("Path", "pathost!demo!whitehouse!not-for-mail"),
-                    ]),
-                    new List<string>(0)
-                )
-            );
-
-        yield return () =>
-            (
-                221,
-                "123 <123@poster.com>",
-                (int)ArticleRequestType.Head,
-                ["Invalid header line", "Path: pathost!demo!whitehouse!not-for-mail"],
-                new NntpArticle(
-                    123,
-                    "<123@poster.com>",
-                    NntpGroups.Empty,
-                    new NntpHeaderCollection([new("Path", "pathost!demo!whitehouse!not-for-mail")]),
-                    new List<string>(0)
-                )
-            );
+        var bytes =
+            lines.Length == 0
+                ? []
+                : UsenetEncoding.Default.GetBytes(string.Join("\r\n", lines) + "\r\n");
+        var buffer = ArrayPool<byte>.Shared.Rent(Math.Max(bytes.Length, 1));
+        bytes.CopyTo(buffer, 0);
+        return (buffer, bytes.Length);
     }
 
     [Test]
-    [MethodDataSource(nameof(MultiLineParseData))]
-    internal async Task MultiLineResponseShouldBeParsedCorrectly(
-        int responseCode,
-        string responseMessage,
-        int requestType,
-        string[] lines,
-        NntpArticle expectedArticle
-    )
+    public async Task ArticleShouldExposeHeadersAndBody()
     {
-        var articleResponse = new ArticleResponseParser((ArticleRequestType)requestType).Parse(
-            responseCode,
-            responseMessage,
-            lines.ToList()
+        string[] lines =
+        [
+            "Path: pathost!demo!whitehouse!not-for-mail",
+            "From: \"Demo User\" <nobody@example.net>",
+            "",
+            "This is just a test article (1).",
+            "With two lines.",
+        ];
+        var (buffer, length) = BuildDataBlock(lines);
+
+        using var response = new ArticleResponseParser(ArticleRequestType.Article).Parse(
+            220,
+            "123 <123@poster.com>",
+            buffer,
+            length
         );
-        var actualArticle = articleResponse.Article;
-        await Assert.That(actualArticle).IsEqualTo(expectedArticle);
+
+        await Assert.That(response.Success).IsTrue();
+        await Assert.That(response.Number).IsEqualTo(123L);
+        await Assert.That(response.MessageId.ToString()).IsEqualTo("<123@poster.com>");
+        await Assert
+            .That(response.Headers["Path"])
+            .Contains("pathost!demo!whitehouse!not-for-mail");
+        await Assert.That(response.Headers["From"]).Contains("\"Demo User\" <nobody@example.net>");
+        await Assert.That(response.ReadBodyLines()).IsEquivalentTo(ArticleBodyLines);
     }
 
-    public static IEnumerable<Func<(int, string, int, string[])>> InvalidMultiLineParseData()
+    [Test]
+    public async Task BodyShouldExposeBytesAndLines()
     {
-        yield return () => (412, "No newsgroup selected", (int)ArticleRequestType.Article, []);
-        yield return () =>
-            (420, "No current article selected", (int)ArticleRequestType.Article, []);
-        yield return () =>
-            (423, "No article with that number", (int)ArticleRequestType.Article, []);
-        yield return () => (430, "No such article found", (int)ArticleRequestType.Article, []);
+        string[] lines = ["This is just a test article (2).", "With two lines."];
+        var (buffer, length) = BuildDataBlock(lines);
+
+        using var response = new ArticleResponseParser(ArticleRequestType.Body).Parse(
+            222,
+            "123 <123@poster.com>",
+            buffer,
+            length
+        );
+
+        await Assert.That(response.Headers).IsEmpty();
+        await Assert
+            .That(UsenetEncoding.Default.GetString(response.Body.Span))
+            .IsEqualTo("This is just a test article (2).\r\nWith two lines.\r\n");
+        await Assert.That(response.ReadBodyLines()).IsEquivalentTo(BodyLines);
+    }
+
+    [Test]
+    public async Task HeadShouldFoldContinuationLinesAndHaveEmptyBody()
+    {
+        string[] lines =
+        [
+            "Multi: line1",
+            " line2",
+            " line3",
+            "Path: pathost!demo!whitehouse!not-for-mail",
+        ];
+        var (buffer, length) = BuildDataBlock(lines);
+
+        using var response = new ArticleResponseParser(ArticleRequestType.Head).Parse(
+            221,
+            "123 <123@poster.com>",
+            buffer,
+            length
+        );
+
+        await Assert.That(response.Headers["Multi"]).Contains("line1 line2 line3");
+        await Assert
+            .That(response.Headers["Path"])
+            .Contains("pathost!demo!whitehouse!not-for-mail");
+        await Assert.That(response.Body.Length).IsEqualTo(0);
+        await Assert.That(response.ReadBodyLines()).IsEmpty();
+    }
+
+    [Test]
+    public async Task HeadShouldSkipInvalidHeaderLine()
+    {
+        string[] lines = ["Invalid header line", "Path: pathost!demo!whitehouse!not-for-mail"];
+        var (buffer, length) = BuildDataBlock(lines);
+
+        using var response = new ArticleResponseParser(ArticleRequestType.Head).Parse(
+            221,
+            "123 <123@poster.com>",
+            buffer,
+            length
+        );
+
+        await Assert.That(response.Headers.ContainsKey("Invalid header line")).IsFalse();
+        await Assert
+            .That(response.Headers["Path"])
+            .Contains("pathost!demo!whitehouse!not-for-mail");
+    }
+
+    [Test]
+    public async Task ArticleShouldParseNewsgroupsHeaderIntoGroups()
+    {
+        string[] lines = ["Newsgroups: alt.test,alt.demo", "", "body"];
+        var (buffer, length) = BuildDataBlock(lines);
+
+        using var response = new ArticleResponseParser(ArticleRequestType.Article).Parse(
+            220,
+            "123 <123@poster.com>",
+            buffer,
+            length
+        );
+
+        await Assert.That(response.Groups.ToString()).Contains("alt.test");
+        await Assert.That(response.Groups.ToString()).Contains("alt.demo");
+    }
+
+    public static IEnumerable<Func<(int, string, int)>> InvalidMultiLineParseData()
+    {
+        yield return () => (412, "No newsgroup selected", (int)ArticleRequestType.Article);
+        yield return () => (420, "No current article selected", (int)ArticleRequestType.Article);
+        yield return () => (423, "No article with that number", (int)ArticleRequestType.Article);
+        yield return () => (430, "No such article found", (int)ArticleRequestType.Article);
     }
 
     [Test]
     [MethodDataSource(nameof(InvalidMultiLineParseData))]
-    internal async Task InvalidMultiLineResponseShouldBeParsedCorrectly(
+    internal async Task InvalidResponseShouldNotBeSuccessful(
         int responseCode,
         string responseMessage,
-        int requestType,
-        string[] lines
+        int requestType
     )
     {
-        var articleResponse = new ArticleResponseParser((ArticleRequestType)requestType).Parse(
-            responseCode,
-            responseMessage,
-            lines.ToList()
-        );
-        await Assert.That(articleResponse.Article).IsNull();
-    }
+        var parser = new ArticleResponseParser((ArticleRequestType)requestType);
 
-    /// <summary>
-    /// While headers are being read eagerly, the body is lazily enumerated.
-    /// This means that the body is not read from the stream until it is actually needed.
-    /// Previously, the IEnumerator reading the response data was disposed.
-    /// This causes the IEnumerable to return no data while the underlying stream still contains it.
-    /// Any subsequent command would then receive this data that was still in the stream, causing them to fail.
-    /// </summary>
-    [Test]
-    public async Task LazyEnumerationOfBodyShouldReadFromSourceStream()
-    {
-        const string response = """
-            FirstHeader: FirstValue
-            SecondHeader: SecondValue
+        await Assert.That(parser.IsSuccessResponse(responseCode)).IsFalse();
 
-            This is an
-             example of some
-             body text
-             as returned by
-             the server.
-            """;
-
-        using var stream = new MemoryStream(Encoding.ASCII.GetBytes(response));
-        using var reader = new StreamReader(stream, Encoding.ASCII);
-
-        var data = ReadMultiLineDataBlock(reader);
-        var parser = new ArticleResponseParser(ArticleRequestType.Article);
-        var articleResponse = parser.Parse(220, "", data);
-
-        await Assert.That(articleResponse.Article).IsNotNull();
-        var body = string.Concat(articleResponse.Article!.Body);
-
-        await Assert.That(body).IsNotEmpty();
-    }
-
-    /// <summary>
-    /// Mimics <see cref="Usenet.Nntp.NntpConnection.ReadMultiLineDataBlockAsync"/>
-    /// </summary>
-    private static IEnumerable<string> ReadMultiLineDataBlock(StreamReader reader)
-    {
-        while (reader.ReadLine() is { } line)
-        {
-            yield return line;
-        }
+        using var response = parser.ParseError(responseCode, responseMessage);
+        await Assert.That(response.Success).IsFalse();
+        await Assert.That(response.Body.Length).IsEqualTo(0);
     }
 }

--- a/tests/Usenet.Tests/Nntp/Responses/NntpArticleResponseTests.cs
+++ b/tests/Usenet.Tests/Nntp/Responses/NntpArticleResponseTests.cs
@@ -1,0 +1,77 @@
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using Usenet.Nntp.Parsers;
+using Usenet.Nntp.Responses;
+using Usenet.Util;
+
+namespace Usenet.Tests.Nntp.Responses;
+
+internal sealed class NntpArticleResponseTests
+{
+    private static NntpArticleResponse ParseBody(string body)
+    {
+        var bytes = UsenetEncoding.Default.GetBytes(body);
+        var buffer = ArrayPool<byte>.Shared.Rent(Math.Max(bytes.Length, 1));
+        bytes.CopyTo(buffer, 0);
+        return new ArticleResponseParser(ArticleRequestType.Body).Parse(
+            222,
+            "1 <1@example>",
+            buffer,
+            bytes.Length
+        );
+    }
+
+    [Test]
+    public async Task DoubleDisposeIsSafeAndBodyThrowsAfterwards()
+    {
+        var response = ParseBody("body line\r\n");
+
+        DisposeTwice(response);
+
+        await Assert.That(() => _ = response.Body).ThrowsExactly<ObjectDisposedException>();
+
+        // A second, synchronous Dispose must be a safe no-op.
+        static void DisposeTwice(NntpArticleResponse response)
+        {
+            response.Dispose();
+            response.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task ReadBodyLinesThrowsAfterDispose()
+    {
+        var response = ParseBody("body line\r\n");
+        await response.DisposeAsync();
+
+        await Assert.That(() => response.ReadBodyLines()).ThrowsExactly<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task DisposeAsyncReturnsBufferAndInvalidatesBody()
+    {
+        var response = ParseBody("body line\r\n");
+
+        await response.DisposeAsync();
+
+        await Assert.That(() => _ = response.Body).ThrowsExactly<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task ForgottenResponseIsReclaimedByFinalizer()
+    {
+        var before = NntpArticleResponse.LeakedBufferCount;
+
+        AbandonResponse();
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        await Assert.That(NntpArticleResponse.LeakedBufferCount).IsGreaterThan(before);
+
+        // A reference must not be kept on the stack, or the finalizer never runs.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void AbandonResponse() => _ = ParseBody("leaked body line\r\n");
+    }
+}

--- a/tests/Usenet.Tests/Nntp/Writers/ArticleWriterTests.cs
+++ b/tests/Usenet.Tests/Nntp/Writers/ArticleWriterTests.cs
@@ -160,6 +160,12 @@ internal sealed class MockConnection : INntpConnection
         CancellationToken cancellationToken
     ) => throw new NotImplementedException();
 
+    public Task<TResponse> BufferedMultiLineCommandAsync<TResponse>(
+        string command,
+        IBufferedMultiLineResponseParser<TResponse> parser,
+        CancellationToken cancellationToken
+    ) => throw new NotImplementedException();
+
     public Task<TResponse> GetResponseAsync<TResponse>(IResponseParser<TResponse> parser) =>
         throw new NotImplementedException();
 


### PR DESCRIPTION
Makes the ARTICLE/HEAD/BODY read path byte-oriented with a pooled, caller-owned response (ADR-0001 reaffirmed, ADR-0002).

## Transport
`NntpConnection.BufferedMultiLineCommandAsync` materializes the multi-line data block into a single contiguous buffer rented from `ArrayPool`, undoing dot-stuffing and detecting the terminating dot on the raw bytes — no per-line `string` transcoding of the body. Ownership of the buffer is handed to the parser; on a parse failure the connection returns the buffer to the pool.

## Response
`NntpArticleResponse` is now `IDisposable`/`IAsyncDisposable` and owns the buffer:
- `Body` → `ReadOnlyMemory<byte>` for binary/XML consumers.
- `ReadBodyLines()` / `ReadBodyLines(Encoding)` → text lines on demand for plain-text consumers.
- `Number`/`MessageId`/`Groups`/`Headers` carry the article metadata (the old `.Article` string-lines view is removed; the post/write `NntpArticle` keeps its text body).
- `Dispose()`/`DisposeAsync()` return the buffer and `SuppressFinalize`; a forgotten response is reclaimed by a finalizer that returns the buffer and increments the diagnostic `LeakedBufferCount`.

`ArticleResponseParser` parses headers + the blank-line separator as text off the buffer while leaving the body bytes untouched.

## Tests & benchmark
Tests cover the bytes view, text-on-demand lines, double dispose, use-after-dispose throwing `ObjectDisposedException`, the finalizer leak path, and an end-to-end byte read with dot-unstuffing. `NntpBenchmarks.ArticleRead` (`[MemoryDiagnoser]`) measures the byte path.

Checks: csharpier clean, build clean on net8.0;net10.0 (TreatWarningsAsErrors/AnalysisMode=All), 268 tests green.

Refs: #117