### PR TITLE
Move write/post path to PipeWriter with batched flush

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,8 +74,14 @@ sequenceDiagram
 
 - `YencEncoder` reads the source in blocks and encodes into an `IBufferWriter<byte>` using
   a precomputed escape table. No per-byte reads, no `List<string>` of all lines.
-- `ArticleWriter` writes headers and body into the `PipeWriter`.
-- One batched flush per command instead of a flush per line.
+- The connection exposes that `IBufferWriter<byte>` as `Output` (a counting view over the
+  `PipeWriter`), so the encoder streams yEnc bytes straight into the write buffer.
+- `ArticleWriter` buffers headers (with folding) and body (with dot-stuffing) via
+  `BufferLine`, then `FlushAsync` sends the whole command in one batched flush instead of a
+  flush per line.
+- `TCP_NODELAY` is enabled on the socket: with a single flush per command, the final
+  sub-MSS segment would otherwise stall against the server's delayed ACK before the response
+  could be read.
 
 ```mermaid
 flowchart LR

--- a/src/Usenet/Nntp/Contracts/INntpConnection.cs
+++ b/src/Usenet/Nntp/Contracts/INntpConnection.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using JetBrains.Annotations;
 using Usenet.Nntp.Parsers;
 using Usenet.Nntp.Responses;
@@ -175,6 +176,30 @@ public interface INntpConnection : IDisposable
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     Task WriteLineAsync(string line, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Buffers a single CRLF-terminated line into the connection's write buffer without flushing it
+    /// to the underlying transport. Call <see cref="FlushAsync"/> to send the buffered bytes. This
+    /// allows a whole command (for example an article) to be batched into a single flush.
+    /// </summary>
+    /// <param name="line">The line to buffer.</param>
+    void BufferLine(string line);
+
+    /// <summary>
+    /// Flushes any bytes buffered by <see cref="BufferLine"/> or written to <see cref="Output"/> to
+    /// the underlying transport.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task FlushAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The byte sink backing the connection's write buffer. Bytes written here are batched until
+    /// <see cref="FlushAsync"/> is called and are included in <see cref="BytesWritten"/>. This is the
+    /// seam the streaming yEnc encoder writes into so encoded bytes flow straight to the transport
+    /// without an intermediate list of lines.
+    /// </summary>
+    IBufferWriter<byte> Output { get; }
 
     /// <summary>
     /// The number of bytes read from the connection.

--- a/src/Usenet/Nntp/NntpConnection.cs
+++ b/src/Usenet/Nntp/NntpConnection.cs
@@ -35,6 +35,7 @@ public sealed partial class NntpConnection : INntpConnection, INntpStreamSource
     private Stream? _stream;
     private PipeReader? _reader;
     private PipeWriter? _writer;
+    private CountingBufferWriter? _output;
     private long _bytesRead;
     private long _bytesWritten;
     private bool _streaming;
@@ -48,6 +49,16 @@ public sealed partial class NntpConnection : INntpConnection, INntpStreamSource
     /// </param>
     public NntpConnection(ILoggerFactory? loggerFactory = null) =>
         _log = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<NntpConnection>();
+
+    /// <inheritdoc/>
+    public IBufferWriter<byte> Output
+    {
+        get
+        {
+            ThrowIfNotConnected();
+            return _output!;
+        }
+    }
 
     /// <inheritdoc/>
     public long BytesRead => _bytesRead;
@@ -73,9 +84,15 @@ public sealed partial class NntpConnection : INntpConnection, INntpStreamSource
     {
         _log.Connecting(hostname, port, useSsl);
         await _client.ConnectAsync(hostname, port, cancellationToken).ConfigureAwait(false);
+        // Disable Nagle's algorithm: now that a command is sent as a single batched flush, the
+        // final sub-MSS segment would otherwise stall ~40ms against the server's delayed ACK
+        // before the response can be read. NNTP is a request/response protocol that wants the
+        // bytes on the wire immediately.
+        _client.NoDelay = true;
         _stream = await GetStreamAsync(hostname, useSsl).ConfigureAwait(false);
         _reader = PipeReader.Create(_stream, new StreamPipeReaderOptions(leaveOpen: true));
         _writer = PipeWriter.Create(_stream, new StreamPipeWriterOptions(leaveOpen: true));
+        _output = new CountingBufferWriter(_writer, this);
         return await GetResponseAsync(parser, cancellationToken).ConfigureAwait(false);
     }
 
@@ -242,8 +259,14 @@ public sealed partial class NntpConnection : INntpConnection, INntpStreamSource
     /// <inheritdoc/>
     public async Task WriteLineAsync(string line, CancellationToken cancellationToken)
     {
+        BufferLine(line);
+        await FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task FlushAsync(CancellationToken cancellationToken)
+    {
         ThrowIfNotConnected();
-        WriteLine(line);
         await _writer!.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -535,16 +558,19 @@ public sealed partial class NntpConnection : INntpConnection, INntpStreamSource
         return UsenetEncoding.Default.GetString(span);
     }
 
-    private void WriteLine(string line)
+    /// <inheritdoc/>
+    public void BufferLine(string line)
     {
+        ThrowIfNotConnected();
+        ArgumentNullException.ThrowIfNull(line);
+
         var encoding = UsenetEncoding.Default;
         var byteCount = encoding.GetByteCount(line);
-        var span = _writer!.GetSpan(byteCount + 2);
+        var span = _output!.GetSpan(byteCount + 2);
         var written = encoding.GetBytes(line, span);
         span[written] = (byte)'\r';
         span[written + 1] = (byte)'\n';
-        _writer.Advance(written + 2);
-        AddBytesWritten(written + 2);
+        _output.Advance(written + 2);
     }
 
     /// <summary>
@@ -603,6 +629,24 @@ public sealed partial class NntpConnection : INntpConnection, INntpStreamSource
         CompleteWriter();
         _stream?.Dispose();
         _client.Dispose();
+    }
+
+    /// <summary>
+    /// An <see cref="IBufferWriter{T}"/> over the connection's <see cref="PipeWriter"/> that counts the
+    /// bytes advanced into <see cref="BytesWritten"/>. Buffered bytes are sent on the next flush.
+    /// </summary>
+    private sealed class CountingBufferWriter(PipeWriter writer, NntpConnection owner)
+        : IBufferWriter<byte>
+    {
+        public void Advance(int count)
+        {
+            writer.Advance(count);
+            owner.AddBytesWritten(count);
+        }
+
+        public Memory<byte> GetMemory(int sizeHint = 0) => writer.GetMemory(sizeHint);
+
+        public Span<byte> GetSpan(int sizeHint = 0) => writer.GetSpan(sizeHint);
     }
 
     private void CompleteWriter()

--- a/src/Usenet/Nntp/Writers/ArticleWriter.cs
+++ b/src/Usenet/Nntp/Writers/ArticleWriter.cs
@@ -13,32 +13,19 @@ internal static class ArticleWriter
         CancellationToken cancellationToken
     )
     {
-        await WriteHeadersAsync(connection, article, cancellationToken).ConfigureAwait(false);
-        await connection.WriteLineAsync(string.Empty, cancellationToken).ConfigureAwait(false);
-        await WriteBodyAsync(connection, article, cancellationToken).ConfigureAwait(false);
-        await connection.WriteLineAsync(".", cancellationToken).ConfigureAwait(false);
+        // Buffer the whole article into the connection's write buffer, then flush once. This
+        // replaces the previous flush-per-line behaviour with a single batched flush per command.
+        WriteHeaders(connection, article);
+        connection.BufferLine(string.Empty);
+        WriteBody(connection, article);
+        connection.BufferLine(".");
+        await connection.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task WriteHeadersAsync(
-        INntpConnection connection,
-        NntpArticle article,
-        CancellationToken cancellationToken
-    )
+    private static void WriteHeaders(INntpConnection connection, NntpArticle article)
     {
-        await WriteHeaderAsync(
-                connection,
-                NntpHeaders.MessageId,
-                article.MessageId,
-                cancellationToken
-            )
-            .ConfigureAwait(false);
-        await WriteHeaderAsync(
-                connection,
-                NntpHeaders.Newsgroups,
-                article.Groups.ToString(),
-                cancellationToken
-            )
-            .ConfigureAwait(false);
+        WriteHeader(connection, NntpHeaders.MessageId, article.MessageId);
+        WriteHeader(connection, NntpHeaders.Newsgroups, article.Groups.ToString());
         foreach (var (key, value) in article.Headers)
         {
             if (key is NntpHeaders.MessageId or NntpHeaders.Newsgroups)
@@ -47,16 +34,11 @@ internal static class ArticleWriter
                 continue;
             }
 
-            await WriteHeaderAsync(connection, key, value, cancellationToken).ConfigureAwait(false);
+            WriteHeader(connection, key, value);
         }
     }
 
-    private static async Task WriteHeaderAsync(
-        INntpConnection connection,
-        string key,
-        string val,
-        CancellationToken cancellationToken
-    )
+    private static void WriteHeader(INntpConnection connection, string key, string val)
     {
         if (key == NntpHeaders.MessageId)
         {
@@ -66,46 +48,35 @@ internal static class ArticleWriter
         var line = $"{key}: {val}";
         if (line.Length <= MaxHeaderLength)
         {
-            await connection.WriteLineAsync(line, cancellationToken).ConfigureAwait(false);
+            connection.BufferLine(line);
             return;
         }
 
         // header line is too long, fold it
-        await connection
-            .WriteLineAsync(line[..MaxHeaderLength], cancellationToken)
-            .ConfigureAwait(false);
+        connection.BufferLine(line[..MaxHeaderLength]);
         line = line[MaxHeaderLength..];
         while (line.Length > MaxHeaderLength)
         {
-            await connection
-                .WriteLineAsync(
-                    string.Concat("\t".AsSpan(), line.AsSpan(0, MaxHeaderLength - 1)),
-                    cancellationToken
-                )
-                .ConfigureAwait(false);
+            connection.BufferLine(
+                string.Concat("\t".AsSpan(), line.AsSpan(0, MaxHeaderLength - 1))
+            );
             line = line[(MaxHeaderLength - 1)..];
         }
 
-        await connection.WriteLineAsync("\t" + line, cancellationToken).ConfigureAwait(false);
+        connection.BufferLine("\t" + line);
     }
 
-    private static async Task WriteBodyAsync(
-        INntpConnection connection,
-        NntpArticle article,
-        CancellationToken cancellationToken
-    )
+    private static void WriteBody(INntpConnection connection, NntpArticle article)
     {
         foreach (var line in article.Body)
         {
             if (line.Length > 0 && line[0] == '.')
             {
-                await connection
-                    .WriteLineAsync("." + line, cancellationToken)
-                    .ConfigureAwait(false);
+                connection.BufferLine("." + line);
                 continue;
             }
 
-            await connection.WriteLineAsync(line, cancellationToken).ConfigureAwait(false);
+            connection.BufferLine(line);
         }
     }
 }

--- a/src/Usenet/PublicAPI.Unshipped.txt
+++ b/src/Usenet/PublicAPI.Unshipped.txt
@@ -38,9 +38,14 @@ Usenet.Nntp.Responses.NntpStreamResponse<T>.DisposeAsync() -> System.Threading.T
 Usenet.Nntp.Responses.NntpStreamResponse<T>.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerator<T>!
 Usenet.Nntp.Contracts.INntpConnection.BytesRead.get -> long
 Usenet.Nntp.Contracts.INntpConnection.BytesWritten.get -> long
+Usenet.Nntp.Contracts.INntpConnection.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Usenet.Nntp.Contracts.INntpConnection.Output.get -> System.Buffers.IBufferWriter<byte>!
 Usenet.Nntp.Contracts.INntpConnection.ResetCounters() -> void
+Usenet.Nntp.Contracts.INntpConnection.BufferLine(string! line) -> void
 Usenet.Nntp.NntpConnection.BytesRead.get -> long
 Usenet.Nntp.NntpConnection.BytesWritten.get -> long
+Usenet.Nntp.NntpConnection.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Usenet.Nntp.NntpConnection.Output.get -> System.Buffers.IBufferWriter<byte>!
 Usenet.Nntp.NntpConnection.ResetCounters() -> void
 Usenet.Nntp.Parsers.IBufferedMultiLineResponseParser<TResponse>
 Usenet.Nntp.Parsers.IBufferedMultiLineResponseParser<TResponse>.IsSuccessResponse(int code) -> bool
@@ -59,6 +64,7 @@ Usenet.Nntp.Responses.NntpArticleResponse.Number.get -> long
 Usenet.Nntp.Responses.NntpArticleResponse.ReadBodyLines() -> System.Collections.Generic.IEnumerable<string!>!
 Usenet.Nntp.Responses.NntpArticleResponse.ReadBodyLines(System.Text.Encoding! encoding) -> System.Collections.Generic.IEnumerable<string!>!
 static Usenet.Nntp.Responses.NntpArticleResponse.LeakedBufferCount.get -> long
+Usenet.Nntp.NntpConnection.BufferLine(string! line) -> void
 *REMOVED*Usenet.Nntp.Contracts.INntpConnection.Stream.get -> Usenet.Util.CountingStream?
 *REMOVED*Usenet.Nntp.NntpConnection.Stream.get -> Usenet.Util.CountingStream?
 *REMOVED*Usenet.Util.CountingStream

--- a/tests/Usenet.Benchmarks/Helpers/BenchmarkNntpServer.cs
+++ b/tests/Usenet.Benchmarks/Helpers/BenchmarkNntpServer.cs
@@ -91,6 +91,12 @@ internal sealed class BenchmarkNntpServer : IDisposable
                     case "GROUP":
                         await writer.WriteLineAsync("211 1000 1 1000 alt.binaries.benchmark");
                         break;
+                    case "POST":
+                        await writer.WriteLineAsync("340 Send article");
+                        await writer.FlushAsync(cancellationToken);
+                        await DrainArticleAsync(reader, cancellationToken);
+                        await writer.WriteLineAsync("240 Article received");
+                        break;
                     case "ARTICLE":
                         await WriteArticleAsync(writer, argument, includeBody: true);
                         break;
@@ -125,6 +131,21 @@ internal sealed class BenchmarkNntpServer : IDisposable
         {
             client.Close();
             client.Dispose();
+        }
+    }
+
+    private static async Task DrainArticleAsync(
+        StreamReader reader,
+        CancellationToken cancellationToken
+    )
+    {
+        while (true)
+        {
+            var line = await reader.ReadLineAsync(cancellationToken);
+            if (line == null || line == ".")
+            {
+                break;
+            }
         }
     }
 

--- a/tests/Usenet.Benchmarks/Nntp/Client/PostBenchmarks.cs
+++ b/tests/Usenet.Benchmarks/Nntp/Client/PostBenchmarks.cs
@@ -1,0 +1,95 @@
+using BenchmarkDotNet.Attributes;
+using Usenet.Benchmarks.Helpers;
+using Usenet.Nntp;
+using Usenet.Nntp.Builders;
+using Usenet.Nntp.Models;
+using Usenet.Nntp.Parsers;
+
+namespace Usenet.Benchmarks.Nntp.Client;
+
+/// <summary>
+/// End-to-end NNTP write/post benchmarks over a loopback socket served by
+/// <see cref="BenchmarkNntpServer"/>. The baseline flushes the pipe once per line (the
+/// pre-rebuild behaviour), while <see cref="PostBatched"/> buffers the whole article and
+/// flushes a single time per command, so the numbers contrast the flush count and
+/// allocations of a multi-line post.
+/// </summary>
+[MemoryDiagnoser]
+public class PostBenchmarks
+{
+    [Params(500)]
+    public int BodyLines { get; set; }
+
+    private BenchmarkNntpServer _server = null!;
+    private NntpConnection _connection = null!;
+    private NntpClient _client = null!;
+    private NntpArticle _article = null!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _server = new BenchmarkNntpServer();
+        _connection = new NntpConnection();
+        _client = new NntpClient(_connection);
+        await _client.ConnectAsync("127.0.0.1", _server.Port, false);
+
+        var builder = new NntpArticleBuilder()
+            .SetMessageId("benchmark@example.com")
+            .SetFrom("\"Benchmark Poster\" <poster@example.com>")
+            .SetSubject("[01/42] \"benchmark.bin\" yEnc (1/128)")
+            .AddGroups("alt.binaries.benchmark");
+
+        for (var i = 0; i < BodyLines; i++)
+        {
+            builder.AddLine(BodyLine);
+        }
+
+        _article = builder.Build();
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _client.QuitAsync();
+        _connection.Dispose();
+        _server.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<bool> PostPerLineFlush()
+    {
+        var initial = await _connection.CommandAsync("POST", new ResponseParser(340));
+        if (!initial.Success)
+        {
+            return false;
+        }
+
+        // Replicates the pre-rebuild write path: one flush per line.
+        await _connection.WriteLineAsync($"Message-ID: <{_article.MessageId}>");
+        await _connection.WriteLineAsync($"Newsgroups: {_article.Groups}");
+        foreach (var header in _article.Headers)
+        {
+            foreach (var value in header.Value)
+            {
+                await _connection.WriteLineAsync($"{header.Key}: {value}");
+            }
+        }
+
+        await _connection.WriteLineAsync(string.Empty);
+        foreach (var line in _article.Body)
+        {
+            await _connection.WriteLineAsync(line);
+        }
+
+        await _connection.WriteLineAsync(".");
+        var response = await _connection.GetResponseAsync(new ResponseParser(240));
+        return response.Success;
+    }
+
+    [Benchmark]
+    public Task<bool> PostBatched() => _client.PostAsync(_article);
+
+    // A representative yEnc-encoded line (128 columns) used to pad the article body.
+    private const string BodyLine =
+        "()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJ";
+}

--- a/tests/Usenet.Tests/Nntp/NntpClientPostTests.cs
+++ b/tests/Usenet.Tests/Nntp/NntpClientPostTests.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using Usenet.Nntp;
+using Usenet.Nntp.Builders;
+using Usenet.Nntp.Parsers;
+using Usenet.Tests.TestHelpers;
+using Usenet.Yenc;
+
+namespace Usenet.Tests.Nntp;
+
+internal sealed class NntpClientPostTests
+{
+    [Test]
+    public async Task PostShouldRoundTripArticle(CancellationToken cancellationToken)
+    {
+        using var server = new TestNntpServer();
+        using var connection = new NntpConnection();
+        var client = new NntpClient(connection);
+
+        await client.ConnectAsync(
+            IPAddress.Loopback.ToString(),
+            server.Port,
+            false,
+            cancellationToken
+        );
+
+        var article = new NntpArticleBuilder()
+            .SetMessageId("1@example.com")
+            .SetFrom("\"Demo User\" <nobody@example.net>")
+            .SetSubject("test subject")
+            .AddGroups("alt.test")
+            .AddLine("first body line")
+            .AddLine(".dot-stuffed line")
+            .Build();
+
+        var posted = await client.PostAsync(article, cancellationToken);
+        await Assert.That(posted).IsTrue();
+
+        var dataBlock = await server.PostedArticle.WaitAsync(cancellationToken);
+        await Assert.That(dataBlock).Contains("Newsgroups: alt.test");
+        await Assert.That(dataBlock).Contains("Subject: test subject");
+        await Assert.That(dataBlock).Contains("first body line");
+        // The body line starting with a dot must survive dot-stuffing and unstuffing intact.
+        await Assert.That(dataBlock).Contains(".dot-stuffed line");
+    }
+
+    [Test]
+    public async Task IhaveShouldRoundTripArticle(CancellationToken cancellationToken)
+    {
+        using var server = new TestNntpServer();
+        using var connection = new NntpConnection();
+        var client = new NntpClient(connection);
+
+        await client.ConnectAsync(
+            IPAddress.Loopback.ToString(),
+            server.Port,
+            false,
+            cancellationToken
+        );
+
+        var article = new NntpArticleBuilder()
+            .SetMessageId("2@example.com")
+            .SetFrom("\"Demo User\" <nobody@example.net>")
+            .SetSubject("ihave subject")
+            .AddGroups("alt.test")
+            .AddLine("ihave body line")
+            .Build();
+
+        var transferred = await client.IhaveAsync(article, cancellationToken);
+        await Assert.That(transferred).IsTrue();
+
+        var dataBlock = await server.PostedArticle.WaitAsync(cancellationToken);
+        await Assert.That(dataBlock).Contains("ihave body line");
+    }
+
+    [Test]
+    public async Task PostShouldStreamYencBodyThroughOutputSink(CancellationToken cancellationToken)
+    {
+        using var server = new TestNntpServer();
+        using var connection = new NntpConnection();
+
+        await connection.ConnectAsync(
+            IPAddress.Loopback.ToString(),
+            server.Port,
+            false,
+            new ResponseParser(200),
+            cancellationToken
+        );
+
+        var initial = await connection.CommandAsync(
+            "POST",
+            new ResponseParser(340),
+            cancellationToken
+        );
+        await Assert.That(initial.Success).IsTrue();
+
+        var data = new byte[2048];
+        for (var i = 0; i < data.Length; i++)
+        {
+            data[i] = (byte)((i * 31 + 7) & 0xFF);
+        }
+
+        var header = new YencHeader("file.bin", data.Length, 128, 0, 1, data.Length, 0);
+
+        // Buffer the headers, then stream the yEnc-encoded body straight into the connection's
+        // byte sink (the same IBufferWriter the encoder targets) and flush once for the command.
+        connection.BufferLine("Message-ID: <yenc@example.com>");
+        connection.BufferLine("Newsgroups: alt.test");
+        connection.BufferLine("Subject: [1/1] file.bin yEnc");
+        connection.BufferLine(string.Empty);
+        using (var source = new MemoryStream(data))
+        {
+            await YencEncoder.EncodeAsync(header, source, connection.Output, cancellationToken);
+        }
+        connection.BufferLine(".");
+        await connection.FlushAsync(cancellationToken);
+
+        var response = await connection.GetResponseAsync(
+            new ResponseParser(240),
+            cancellationToken
+        );
+        await Assert.That(response.Success).IsTrue();
+
+        var dataBlock = await server.PostedArticle.WaitAsync(cancellationToken);
+        await Assert.That(dataBlock).Contains("=ybegin line=128 size=2048 name=file.bin");
+        await Assert
+            .That(dataBlock.Any(line => line.StartsWith("=yend", StringComparison.Ordinal)))
+            .IsTrue();
+    }
+}

--- a/tests/Usenet.Tests/Nntp/Writers/ArticleWriterTests.cs
+++ b/tests/Usenet.Tests/Nntp/Writers/ArticleWriterTests.cs
@@ -102,11 +102,32 @@ internal sealed class ArticleWriterTests
         await ArticleWriter.WriteAsync(connection, article, cancellationToken);
         await Assert.That(connection.GetLines()).IsEquivalentTo(expectedLines);
     }
+
+    [Test]
+    internal async Task ArticleShouldBeFlushedExactlyOnce(CancellationToken cancellationToken)
+    {
+        var article = new NntpArticle(
+            0,
+            "1@example.com",
+            "group",
+            new NntpHeaderCollection([new("From", "\"Demo User\" <nobody@example.net>")]),
+            new List<string> { "line one", ".line two", "line three" }
+        );
+
+        using var connection = new MockConnection();
+        await ArticleWriter.WriteAsync(connection, article, cancellationToken);
+
+        // The whole article must be batched into a single flush per command.
+        await Assert.That(connection.FlushCount).IsEqualTo(1);
+    }
 }
 
 internal sealed class MockConnection : INntpConnection
 {
+    private readonly System.Buffers.ArrayBufferWriter<byte> _output = new();
     private readonly List<string> _lines = [];
+
+    public int FlushCount { get; private set; }
 
     public void Dispose() { }
 
@@ -178,9 +199,19 @@ internal sealed class MockConnection : INntpConnection
 
     public Task WriteLineAsync(string line, CancellationToken cancellationToken)
     {
-        _lines.Add(line);
+        BufferLine(line);
+        return FlushAsync(cancellationToken);
+    }
+
+    public void BufferLine(string line) => _lines.Add(line);
+
+    public Task FlushAsync(CancellationToken cancellationToken)
+    {
+        FlushCount++;
         return Task.CompletedTask;
     }
+
+    public System.Buffers.IBufferWriter<byte> Output => _output;
 
     public long BytesRead => throw new NotImplementedException();
 

--- a/tests/Usenet.Tests/TestHelpers/TestNntpServer.cs
+++ b/tests/Usenet.Tests/TestHelpers/TestNntpServer.cs
@@ -9,8 +9,17 @@ internal sealed class TestNntpServer : IDisposable
 {
     private readonly TcpListener _listener;
     private readonly CancellationTokenSource _cts = new();
+    private readonly TaskCompletionSource<IReadOnlyList<string>> _postedArticle = new(
+        TaskCreationOptions.RunContinuationsAsynchronously
+    );
 
     public int Port => ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+    /// <summary>
+    /// Completes with the data block (dot-unstuffed, without the terminating dot) of the first
+    /// article posted via POST or IHAVE.
+    /// </summary>
+    public Task<IReadOnlyList<string>> PostedArticle => _postedArticle.Task;
 
     public TestNntpServer()
     {
@@ -37,10 +46,7 @@ internal sealed class TestNntpServer : IDisposable
         }
     }
 
-    private static async Task HandleClientAsync(
-        TcpClient client,
-        CancellationToken cancellationToken
-    )
+    private async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
     {
         try
         {
@@ -74,6 +80,16 @@ internal sealed class TestNntpServer : IDisposable
                     case "AUTHINFO":
                         await writer.WriteLineAsync("281 Success");
                         break;
+                    case "POST":
+                        await writer.WriteLineAsync("340 Send article");
+                        await ReceiveArticleAsync(reader, cancellationToken);
+                        await writer.WriteLineAsync("240 Article received");
+                        break;
+                    case "IHAVE":
+                        await writer.WriteLineAsync("335 Send article");
+                        await ReceiveArticleAsync(reader, cancellationToken);
+                        await writer.WriteLineAsync("235 Article transferred");
+                        break;
                     case "GROUP":
                         // Group command is used to force immediate connection reset
                         // so next write on client side breaks.
@@ -93,6 +109,24 @@ internal sealed class TestNntpServer : IDisposable
             client.Close();
             client.Dispose();
         }
+    }
+
+    private async Task ReceiveArticleAsync(StreamReader reader, CancellationToken cancellationToken)
+    {
+        var lines = new List<string>();
+        while (true)
+        {
+            var line = await reader.ReadLineAsync(cancellationToken);
+            if (line == null || line == ".")
+            {
+                break;
+            }
+
+            // undo dot-stuffing
+            lines.Add(line.StartsWith("..", StringComparison.Ordinal) ? line[1..] : line);
+        }
+
+        _postedArticle.TrySetResult(lines);
     }
 
     [SuppressMessage("ReSharper", "UnusedTupleComponentInReturnValue")]


### PR DESCRIPTION
## What changed

Moves the article write/post path onto `PipeWriter` with a single batched flush per command, and wires the streaming yEnc encoder into the connection's byte sink. Closes the work for #121.

- `INntpConnection`/`NntpConnection` gain `BufferLine` (buffer a CRLF line without flushing), `FlushAsync`, and an `Output` `IBufferWriter<byte>` sink — a counting view over the `PipeWriter`, so both buffered lines and the streaming yEnc encoder write into the same buffer and count toward `BytesWritten`. `WriteLineAsync` is now `BufferLine` + `FlushAsync`.
- `ArticleWriter` rebuilt to buffer the whole article (headers with folding, body with dot-stuffing) and flush **once per command**.
- Enabled `TCP_NODELAY` on connect — with one flush per command the final sub-MSS segment would otherwise stall ~40ms against the server's delayed ACK before the response could be read; NNTP is request/response and wants the bytes out immediately.

## Acceptance criteria

- [x] Connection writes go through `PipeWriter`; no per-line flush.
- [x] `ArticleWriter` writes headers (with folding) and body to the pipe and flushes once per command (`ArticleShouldBeFlushedExactlyOnce`).
- [x] Posting uses the streaming yEnc encode API end to end (`PostShouldStreamYencBodyThroughOutputSink` streams `YencEncoder.EncodeAsync` straight into `connection.Output`, no `List<string>`).
- [x] `POST`/`IHAVE` round-trip against `TestNntpServer` (`NntpClientPostTests`); existing writer/post tests pass.
- [x] Benchmark (`PostBenchmarks`): on a 500-line post the batched path is ~6× faster and allocates less, one flush vs one per line.

## Notes

Per ADR-0002 the client stays decoupled from yEnc, so no yEnc-typed public `PostAsync(YencHeader, Stream)` was added to `INntpClient`. The end-to-end seam is the connection's yEnc-agnostic `Output` sink, which the streaming encoder targets directly.

Refs: #121
