### PR TITLE
Add allocation-regression guards and record performance deltas

### DIFF
--- a/docs/adr/0002-byte-oriented-article-bodies.md
+++ b/docs/adr/0002-byte-oriented-article-bodies.md
@@ -56,3 +56,24 @@ segment-loop level — one part in memory at a time, never a whole multi-segment
 - `PipeReader` drives the underlying stream's `ReadAsync`, so byte-counting can no longer
   rely on a sync-`Read`-only `CountingStream` wrapper; counting moves to the pipe layer or
   gains proper async overrides.
+
+## Measured outcomes
+
+Recorded after the rebuild landed (#122). BenchmarkDotNet `ShortRun`, .NET 10, on a single
+64 KiB part; allocations are deterministic across runs, the times are indicative (dev
+hardware, noisy short job). The allocation win — not the wall-clock time — is the point.
+
+| Path | Method | Allocated | vs baseline |
+|------|--------|----------:|------------:|
+| yEnc decode (text, baseline) | `YencArticleDecoder.Decode(lines)` | 143.29 KB | 1.00× |
+| yEnc decode (bytes → pooled `Data`) | `YencDecoder.Decode(bytes)` | **2.19 KB** | 0.02× |
+| yEnc encode (text, baseline) | `EncodeAsync` → `List<string>` | 416.2 KB | 1.00× |
+| yEnc encode (bytes → `IBufferWriter`) | `EncodeAsync` → sink | **920 B** | 0.002× |
+
+The decoded `Data` and the encode sink draw from `ArrayPool<byte>`, so the residual managed
+allocation is just per-call objects, not the payload. The byte decode path is *slower* in
+wall-clock (~171 µs vs ~63 µs) because it also verifies the part `pcrc32` in the same pass;
+that is an accepted trade for the ~98% allocation drop and is dwarfed by network cost.
+
+A `GC.GetAllocatedBytesForCurrentThread()` ceiling on a full part decode is wired into the
+TUnit suite (`YencDecoderAllocationTests`) so a regression back to per-line strings fails CI.

--- a/docs/adr/0003-streaming-multiline-responses.md
+++ b/docs/adr/0003-streaming-multiline-responses.md
@@ -40,3 +40,16 @@ connection), before issuing the next command on that lease.
   enumerator on return to avoid leaving unread bytes on a reused connection.
 - This is the same framing discipline [ADR-0001](0001-article-buffering-and-streaming-model.md)
   established for bodies, now applied to multi-line results.
+
+## Measured outcomes
+
+Recorded after the rebuild landed (#122). The `XOVER` read over a loopback connection
+(BenchmarkDotNet `ShortRun`, .NET 10) allocates ~642 KB to frame and materialize 1000
+overview rows, i.e. **~0.64 KB per row** — dominated by the decoded line `string` and its
+slot in the result list, with the pipe's read buffers drawn from the pool rather than the
+managed heap.
+
+The TUnit suite (`XoverAllocationTests`) measures the *marginal* allocation of a single
+streamed row by reading two ranges and dividing the allocation delta by the row delta, so
+fixed per-command overhead cancels out. That marginal cost measures ~590 B/row and is held
+under a 896 B/row ceiling so a per-row regression (extra copies, boxing) fails CI.

--- a/tests/Usenet.Tests/Nntp/Parsers/ArticleResponseParserAllocationTests.cs
+++ b/tests/Usenet.Tests/Nntp/Parsers/ArticleResponseParserAllocationTests.cs
@@ -1,0 +1,52 @@
+using Usenet.Nntp.Parsers;
+using Usenet.Tests.TestHelpers;
+
+namespace Usenet.Tests.Nntp.Parsers;
+
+/// <summary>
+/// Allocation-regression guard for parsing a single article header block (as returned by
+/// <c>HEAD</c>). This isolates the header-folding and dictionary-building cost from any
+/// network I/O, so a regression in the parse path shows up as extra per-parse allocation.
+/// </summary>
+internal sealed class ArticleResponseParserAllocationTests
+{
+    private const string Message = "123 <message-id@benchmark> head";
+
+    // A representative folded header block, matching the benchmark fixture.
+    private static readonly string[] HeaderBlock =
+    [
+        "Path: news.example.com!not-for-mail",
+        "From: \"Benchmark Poster\" <poster@example.com>",
+        "Newsgroups: alt.binaries.benchmark,alt.binaries.test",
+        "Subject: [01/42] \"benchmark.bin\" yEnc (1/128)",
+        "Date: Sat, 14 Jun 2026 12:00:00 +0000",
+        "Message-ID: <message-id@benchmark>",
+        "References: <parent-1@benchmark> <parent-2@benchmark>",
+        "X-Newsreader: Usenet.Benchmarks",
+        "Organization: Example",
+        "Lines: 1024",
+        // Folded continuation line to exercise the whitespace-continuation path.
+        "X-Long-Header: part-one",
+        "\tpart-two-folded",
+    ];
+
+    // Parsing this twelve-line block allocates ~9.6 KB: the header records and folded-value
+    // strings, the backing dictionary and the article/groups objects. The ceiling sits ~50%
+    // above the measured cost for runtime variation while still tripping if the parse regresses
+    // (e.g. extra copies of the header block or repeated splits).
+    private const long MaxBytesPerParse = 14_336;
+    private const int Iterations = 200;
+
+    [Test]
+    internal async Task ParseShouldStayUnderAllocationCeiling()
+    {
+        var parser = new ArticleResponseParser(ArticleRequestType.Head);
+
+        var perParse = AllocationMeasurement.PerIteration(
+            () => parser.Parse(221, Message, HeaderBlock),
+            Iterations
+        );
+
+        await Assert.That(perParse).IsLessThanOrEqualTo(MaxBytesPerParse);
+    }
+}

--- a/tests/Usenet.Tests/Nntp/XoverAllocationTests.cs
+++ b/tests/Usenet.Tests/Nntp/XoverAllocationTests.cs
@@ -1,0 +1,217 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Usenet.Nntp;
+using Usenet.Nntp.Parsers;
+using Usenet.Tests.TestHelpers;
+
+namespace Usenet.Tests.Nntp;
+
+/// <summary>
+/// Allocation-regression guard for the streamed <c>XOVER</c> read path (ADR-0003). It measures
+/// the <em>marginal</em> managed allocation of a single overview row by reading two ranges of
+/// different sizes over a loopback connection and dividing the allocation delta by the row
+/// delta, so the fixed per-command overhead (command write, status line, socket and pipe setup)
+/// cancels out. The loopback server replies from a pre-built byte buffer, so it does not
+/// allocate per row and only the client framing/parsing is measured.
+/// </summary>
+internal sealed class XoverAllocationTests
+{
+    private const int SmallRange = 200;
+    private const int LargeRange = 2_200;
+
+    // A framed overview row is ~130 bytes of text, so the dominant per-row managed allocation is
+    // the decoded string plus its slot in the materialized list. The ceiling leaves headroom for
+    // runtime variation but trips if the per-row cost grows (e.g. extra copies or boxing).
+    private const long MaxBytesPerRow = 896;
+
+    [Test]
+    internal async Task StreamedOverviewRowShouldStayUnderAllocationCeiling(
+        CancellationToken cancellationToken
+    )
+    {
+        await using var server = new OverviewNntpServer();
+        using var connection = new NntpConnection();
+
+        await connection.ConnectAsync(
+            IPAddress.Loopback.ToString(),
+            server.Port,
+            false,
+            new ResponseParser(200),
+            cancellationToken
+        );
+
+        // Warm up both ranges so cached server buffers and JIT costs stay out of the window.
+        await ReadOverviewAsync(connection, SmallRange, cancellationToken);
+        await ReadOverviewAsync(connection, LargeRange, cancellationToken);
+
+        // Take the lowest marginal cost over a few repetitions to filter transient background
+        // noise from the runtime and the loopback server thread.
+        var perRow = long.MaxValue;
+        for (var repeat = 0; repeat < 5; repeat++)
+        {
+            var smallBytes = await AllocationMeasurement.TotalAsync(() =>
+                ReadOverviewAsync(connection, SmallRange, cancellationToken)
+            );
+            var largeBytes = await AllocationMeasurement.TotalAsync(() =>
+                ReadOverviewAsync(connection, LargeRange, cancellationToken)
+            );
+
+            var marginal = (largeBytes - smallBytes) / (LargeRange - SmallRange);
+            perRow = Math.Min(perRow, marginal);
+        }
+
+        await Assert.That(perRow).IsLessThanOrEqualTo(MaxBytesPerRow);
+    }
+
+    private static async Task ReadOverviewAsync(
+        NntpConnection connection,
+        int count,
+        CancellationToken cancellationToken
+    )
+    {
+        var response = await connection.MultiLineCommandAsync(
+            string.Create(CultureInfo.InvariantCulture, $"XOVER 1-{count}"),
+            new MultiLineResponseParser(224),
+            cancellationToken
+        );
+
+        if (response.Lines.Count != count)
+        {
+            throw new InvalidOperationException(
+                $"Expected {count} overview rows, got {response.Lines.Count}."
+            );
+        }
+    }
+
+    /// <summary>
+    /// A minimal loopback NNTP server that replies to <c>XOVER from-to</c> with a pre-built,
+    /// cached byte buffer so it allocates nothing per row while the client read is measured.
+    /// </summary>
+    private sealed class OverviewNntpServer : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly ConcurrentDictionary<int, byte[]> _cache = new();
+
+        public int Port => ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+        public OverviewNntpServer()
+        {
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            _ = AcceptLoop();
+        }
+
+        private async Task AcceptLoop()
+        {
+            var cancellationToken = _cts.Token;
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                TcpClient client;
+                try
+                {
+                    client = await _listener.AcceptTcpClientAsync(cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+
+                _ = Task.Run(() => HandleClientAsync(client, cancellationToken), cancellationToken);
+            }
+        }
+
+        private async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var stream = client.GetStream();
+                using var reader = new StreamReader(
+                    stream,
+                    Encoding.ASCII,
+                    false,
+                    1024,
+                    leaveOpen: true
+                );
+
+                await stream.WriteAsync(
+                    Encoding.ASCII.GetBytes("200 Overview server ready\r\n"),
+                    cancellationToken
+                );
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var line = await reader.ReadLineAsync(cancellationToken);
+                    if (line == null)
+                        break;
+
+                    if (line.StartsWith("XOVER", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var count = ParseRangeCount(line);
+                        var payload = _cache.GetOrAdd(count, BuildOverview);
+                        await stream.WriteAsync(payload, cancellationToken);
+                    }
+                    else if (line.StartsWith("QUIT", StringComparison.OrdinalIgnoreCase))
+                    {
+                        await stream.WriteAsync(
+                            Encoding.ASCII.GetBytes("205 Goodbye\r\n"),
+                            cancellationToken
+                        );
+                        return;
+                    }
+                    else
+                    {
+                        await stream.WriteAsync(
+                            Encoding.ASCII.GetBytes("500 Command not recognized\r\n"),
+                            cancellationToken
+                        );
+                    }
+                }
+            }
+            catch (IOException)
+            {
+                // Client disconnected.
+            }
+            catch (OperationCanceledException)
+            {
+                // Server shutting down.
+            }
+            finally
+            {
+                client.Close();
+                client.Dispose();
+            }
+        }
+
+        private static int ParseRangeCount(string command)
+        {
+            var dash = command.IndexOf('-', StringComparison.Ordinal);
+            return dash < 0 ? 1 : int.Parse(command.AsSpan(dash + 1), CultureInfo.InvariantCulture);
+        }
+
+        private static byte[] BuildOverview(int count)
+        {
+            var builder = new StringBuilder("224 Overview information follows\r\n");
+            for (var number = 1; number <= count; number++)
+            {
+                builder.Append(
+                    CultureInfo.InvariantCulture,
+                    $"{number}\t[01/42] \"benchmark.bin\" yEnc (1/128)\tposter@example.com\tSat, 14 Jun 2026 12:00:00 +0000\t<{number}@benchmark>\t<parent@benchmark>\t8192\t128\r\n"
+                );
+            }
+            builder.Append(".\r\n");
+            return Encoding.ASCII.GetBytes(builder.ToString());
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _cts.CancelAsync();
+            _listener.Stop();
+            _cts.Dispose();
+            _listener.Dispose();
+        }
+    }
+}

--- a/tests/Usenet.Tests/TestHelpers/AllocationMeasurement.cs
+++ b/tests/Usenet.Tests/TestHelpers/AllocationMeasurement.cs
@@ -1,0 +1,59 @@
+namespace Usenet.Tests.TestHelpers;
+
+/// <summary>
+/// Helpers for measuring managed-heap allocations so the suite can guard the rebuilt
+/// hot paths against allocation regressions. Buffers rented from <see cref="System.Buffers.ArrayPool{T}"/>
+/// are deliberately not counted here: the byte-oriented paths (ADR-0002) rent their working
+/// buffers, so the managed allocation that remains is the per-call object/string churn.
+/// </summary>
+internal static class AllocationMeasurement
+{
+    /// <summary>
+    /// Runs a synchronous action <paramref name="iterations"/> times on the calling thread and
+    /// returns the average managed bytes allocated per iteration. The action is run once first to
+    /// pay one-off JIT and static-init costs, then the heap is settled before measuring.
+    /// </summary>
+    public static long PerIteration(Action action, int iterations)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(iterations);
+
+        // Warm up so first-call JIT and one-off allocations don't land in the measured window.
+        action();
+        Settle();
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < iterations; i++)
+        {
+            action();
+        }
+        var after = GC.GetAllocatedBytesForCurrentThread();
+
+        return (after - before) / iterations;
+    }
+
+    /// <summary>
+    /// Measures the total managed bytes allocated across all threads while awaiting
+    /// <paramref name="action"/>. Uses the process-wide counter because async work can hop
+    /// threads, which the per-thread counter cannot follow. Intended to be paired with a
+    /// marginal (delta-between-sizes) measurement so fixed per-call overhead cancels out.
+    /// </summary>
+    public static async Task<long> TotalAsync(Func<Task> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        Settle();
+        var before = GC.GetTotalAllocatedBytes(precise: true);
+        await action();
+        var after = GC.GetTotalAllocatedBytes(precise: true);
+
+        return after - before;
+    }
+
+    private static void Settle()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+}

--- a/tests/Usenet.Tests/Yenc/YencDecoderAllocationTests.cs
+++ b/tests/Usenet.Tests/Yenc/YencDecoderAllocationTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.FileProviders;
+using Usenet.Tests.Extensions;
+using Usenet.Tests.TestHelpers;
+using Usenet.Yenc;
+
+namespace Usenet.Tests.Yenc;
+
+/// <summary>
+/// Allocation-regression guard for the byte-oriented yEnc decode path (ADR-0002). The decoded
+/// data lands in a pooled buffer, so a full part decode should allocate only the small set of
+/// per-call objects (header dictionary, meta-data records, the part itself) and stay well clear
+/// of the per-line <see cref="string"/> churn of the text-based decoder it replaced.
+/// </summary>
+internal sealed class YencDecoderAllocationTests
+{
+    // Decoding the ~11 KB multipart sample allocates ~3.7 KB of per-call objects on the rebuilt
+    // byte path (header records, meta-data, the part itself) with the decoded data landing in a
+    // pooled buffer; the text decoder it replaced allocated ~140 KB for the same input. The
+    // ceiling sits ~60% above the measured number for runtime variation but more than an order of
+    // magnitude below the old cost, so a regression back to per-line strings trips it.
+    private const long MaxBytesPerDecode = 6_144;
+    private const int Iterations = 200;
+
+    [Test]
+    [MethodDataSource(nameof(GetPartData))]
+    internal async Task DecodeShouldStayUnderAllocationCeiling(IFileInfo part)
+    {
+        var encoded = part.ReadAllBytes();
+
+        var perDecode = AllocationMeasurement.PerIteration(
+            () =>
+            {
+                using var decoded = YencDecoder.Decode(encoded);
+                _ = decoded.Data.Length;
+            },
+            Iterations
+        );
+
+        await Assert.That(perDecode).IsLessThanOrEqualTo(MaxBytesPerDecode);
+    }
+
+    public static IEnumerable<Func<IFileInfo>> GetPartData()
+    {
+        yield return () => EmbeddedResourceHelper.GetFileInfo("yenc.multipart.00000020.ntx");
+    }
+}


### PR DESCRIPTION
Closes #122 (do not auto-close yet).

## What this adds

Allocation-bound regression guards wired into the TUnit suite for the three rebuilt hot paths, so a regression back to per-line strings or extra per-row copies **fails CI** instead of slipping through. Plus a re-run of the BenchmarkDotNet suite with the before/after numbers annotated into ADR-0002 and ADR-0003.

### Regression tests (run in CI)

| Test | Path | Measured | Ceiling | Counter |
|------|------|---------:|--------:|---------|
| `YencDecoderAllocationTests` | yEnc decode (byte → pooled `Data`) | ~3.7 KB/decode | 6 KiB | `GetAllocatedBytesForCurrentThread` |
| `ArticleResponseParserAllocationTests` | header (`HEAD`) parse | ~9.6 KB/parse | 14 KiB | `GetAllocatedBytesForCurrentThread` |
| `XoverAllocationTests` | streamed `XOVER` row | ~590 B/row | 896 B | `GetTotalAllocatedBytes` (marginal, two-range delta) |

The sync paths use the per-thread counter. The async `XOVER` path can hop threads, so it uses the process-wide counter paired with a loopback server that replies from a **cached** buffer (zero per-row server allocation), and measures the *marginal* per-row cost as the allocation delta between a small and large range divided by the row delta — fixed per-command overhead cancels out. Ceilings are set from the measured numbers with ~1.5× headroom; allocation counts are deterministic across runs.

## Recorded benchmark deltas

BenchmarkDotNet `ShortRun`, .NET 10. Allocations are the headline; times are indicative (dev hardware, short job). 64 KiB part for the yEnc rows.

**yEnc decode (ADR-0002)**

| Method | Mean | Allocated | Alloc ratio |
|--------|-----:|----------:|------------:|
| `DecodeFromLines` (text, baseline) | 62.9 µs | 143.29 KB | 1.00× |
| `DecodeFromBytes` (byte → pooled) | 171.4 µs | **2.19 KB** | 0.02× |

The byte path is slower in wall-clock because it also verifies the part `pcrc32` in the same pass — an accepted trade for the ~98% allocation drop, dwarfed by network cost.

**yEnc encode (ADR-0002, write path)**

| Method | Mean | Allocated | Alloc ratio |
|--------|-----:|----------:|------------:|
| `EncodeToLines` (text, baseline) | 224.7 µs | 416.2 KB | 1.00× |
| `EncodeToWriter` (sink) | 172.0 µs | **920 B** | 0.002× |

**Header parse**

| Method | Mean | Allocated |
|--------|-----:|----------:|
| `ParseHeaders` | 2.51 µs | 9.36 KB |

**NNTP client over loopback (ADR-0003)**

| Method | Mean | Allocated | Per row |
|--------|-----:|----------:|--------:|
| `ArticleRead` | 44.9 ms | 34.71 KB | — |
| `XoverRange` (1000 rows) | 22.2 ms | 642.03 KB | ~0.64 KB |

The ~0.64 KB/row from the full benchmark and the ~590 B/row marginal from the regression test agree.

## ADRs

- **ADR-0002** annotated with the yEnc decode/encode allocation outcomes.
- **ADR-0003** annotated with the `XOVER` per-row allocation outcome and the marginal-measurement method.

## Checks

`csharpier check` clean, `dotnet build` clean on `net8.0;net10.0` (warnings-as-errors / `AnalysisMode=All`), full suite green (267/267).

Refs: #122