### PR TITLE
Consolidate connection and pool configuration into options objects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,9 +25,13 @@ dotnet add package Spottarr.Usenet
 
 ### Connect and authenticate
 
+Connection identity (host, port, SSL) lives on `NntpConnectionOptions`, so `ConnectAsync` reads it
+from configuration rather than taking it as arguments:
+
 ```csharp
-var client = new NntpClient(new NntpConnection());
-await client.ConnectAsync(hostname, port, useSsl);
+var options = new NntpConnectionOptions { Host = hostname, Port = port, UseSsl = useSsl };
+var client = new NntpClient(new NntpConnection(options));
+await client.ConnectAsync();
 await client.AuthenticateAsync(username, password);
 ```
 
@@ -213,7 +217,13 @@ borrowed, and idle clients are disconnected automatically:
 
 ```csharp
 using var pool = new NntpClientPool(
-    maxPoolSize: 10, hostname, port, useSsl, username, password);
+    new NntpPoolOptions
+    {
+        MaxPoolSize = 10,
+        Username = username,
+        Password = password,
+        Connection = new NntpConnectionOptions { Host = hostname, Port = port, UseSsl = useSsl },
+    });
 
 using var lease = await pool.GetLease();
 await using var response = await lease.Client.ArticleAsync(messageId);
@@ -227,9 +237,10 @@ Logging is optional and flows through `Microsoft.Extensions.Logging`. Hand the c
 
 ```csharp
 // direct
-var client = new NntpClient(new NntpConnection(loggerFactory), loggerFactory);
+var connection = new NntpConnection(options, loggerFactory);
+var client = new NntpClient(connection, loggerFactory);
 
-// dependency injection
+// dependency injection — register an NntpConnectionOptions to configure the connection
 services.AddUsenet();
 ```
 

--- a/src/Usenet/DependencyInjection/UsenetServiceCollectionExtensions.cs
+++ b/src/Usenet/DependencyInjection/UsenetServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ public static class UsenetServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.TryAddTransient<INntpConnection>(sp => new NntpConnection(
+            sp.GetService<NntpConnectionOptions>(),
             sp.GetService<ILoggerFactory>()
         ));
 

--- a/src/Usenet/Nntp/Contracts/INntpClientConnection.cs
+++ b/src/Usenet/Nntp/Contracts/INntpClientConnection.cs
@@ -7,19 +7,13 @@ namespace Usenet.Nntp.Contracts;
 public interface INntpClientConnection
 {
     /// <summary>
-    /// Attempts to establish a <a href="https://tools.ietf.org/html/rfc3977#section-5.1">connection</a> with a usenet server.
+    /// Attempts to establish a <a href="https://tools.ietf.org/html/rfc3977#section-5.1">connection</a>
+    /// with a usenet server. The host, port and SSL setting are read from the
+    /// <see cref="NntpConnectionOptions"/> the underlying connection was created with.
     /// </summary>
-    /// <param name="hostname">The hostname of the usenet server.</param>
-    /// <param name="port">The port to use.</param>
-    /// <param name="useSsl">A value to indicate whether or not to use SSL encryption.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>true if a connection was made; otherwise false</returns>
-    Task<bool> ConnectAsync(
-        string hostname,
-        int port,
-        bool useSsl,
-        CancellationToken cancellationToken = default
-    );
+    Task<bool> ConnectAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// The client uses the

--- a/src/Usenet/Nntp/Contracts/INntpConnection.cs
+++ b/src/Usenet/Nntp/Contracts/INntpConnection.cs
@@ -13,19 +13,14 @@ namespace Usenet.Nntp.Contracts;
 public interface INntpConnection : IDisposable
 {
     /// <summary>
-    /// Attempts to establish a connection with a usenet server.
+    /// Attempts to establish a connection with a usenet server. The host, port and SSL setting are
+    /// read from the <see cref="NntpConnectionOptions"/> the connection was created with.
     /// </summary>
     /// <typeparam name="TResponse">The type of the parsed response.</typeparam>
-    /// <param name="hostname">The hostname of the usenet server.</param>
-    /// <param name="port">The port to use.</param>
-    /// <param name="useSsl">A value to indicate whether to use SSL encryption.</param>
     /// <param name="parser">The response parser to use.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A response object of type <typeparamref name="TResponse"/>.</returns>
     Task<TResponse> ConnectAsync<TResponse>(
-        string hostname,
-        int port,
-        bool useSsl,
         IResponseParser<TResponse> parser,
         CancellationToken cancellationToken = default
     );

--- a/src/Usenet/Nntp/NntpClient.cs
+++ b/src/Usenet/Nntp/NntpClient.cs
@@ -62,16 +62,10 @@ public class NntpClient : INntpClient
     }
 
     /// <inheritdoc />
-    public async Task<bool> ConnectAsync(
-        string hostname,
-        int port,
-        bool useSsl,
-        CancellationToken cancellationToken = default
-    )
+    public async Task<bool> ConnectAsync(CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(hostname);
         var response = await Connection
-            .ConnectAsync(hostname, port, useSsl, new ResponseParser(200, 201), cancellationToken)
+            .ConnectAsync(new ResponseParser(200, 201), cancellationToken)
             .ConfigureAwait(false);
         return response.Success;
     }

--- a/src/Usenet/Nntp/NntpClientPool.cs
+++ b/src/Usenet/Nntp/NntpClientPool.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Usenet.Extensions;
 using Usenet.Nntp.Contracts;
-using Usenet.Util;
 
 namespace Usenet.Nntp;
 
@@ -27,9 +26,7 @@ public sealed class NntpClientPool : INntpClientPool
     private readonly SemaphoreSlim _semaphore;
 
     private readonly int _maxPoolSize;
-    private readonly string _hostname;
-    private readonly int _port;
-    private readonly bool _useSsl;
+    private readonly NntpConnectionOptions _connectionOptions;
     private readonly string _username;
     private readonly string _password;
 
@@ -42,30 +39,23 @@ public sealed class NntpClientPool : INntpClientPool
 
     internal Func<IInternalPooledNntpClient> ClientFactory { get; init; }
 
-    public NntpClientPool(
-        int maxPoolSize,
-        string hostname,
-        int port,
-        bool useSsl,
-        string username,
-        string password,
-        ILoggerFactory? loggerFactory = null
-    )
+    public NntpClientPool(NntpPoolOptions options, ILoggerFactory? loggerFactory = null)
     {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPoolSize);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(options.Connection);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(options.MaxPoolSize);
 
         _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
         _logger = _loggerFactory.CreateLogger<NntpClientPool>();
-        ClientFactory = () => new PooledNntpClient(_loggerFactory);
 
-        _semaphore = new SemaphoreSlim(maxPoolSize, maxPoolSize);
+        _maxPoolSize = options.MaxPoolSize;
+        _connectionOptions = options.Connection;
+        _username = options.Username;
+        _password = options.Password;
 
-        _maxPoolSize = maxPoolSize;
-        _hostname = hostname;
-        _port = port;
-        _useSsl = useSsl;
-        _username = username;
-        _password = password;
+        ClientFactory = () => new PooledNntpClient(_connectionOptions, _loggerFactory);
+
+        _semaphore = new SemaphoreSlim(_maxPoolSize, _maxPoolSize);
 
         // Start the background idle-monitor. The task is tracked so it can be awaited
         // to a clean stop on dispose, leaving no orphaned task or timer behind.
@@ -96,9 +86,7 @@ public sealed class NntpClientPool : INntpClientPool
             return client;
 
         if (!client.Connected)
-            await client
-                .ConnectAsync(_hostname, _port, _useSsl, cancellationToken)
-                .ConfigureAwait(false);
+            await client.ConnectAsync(cancellationToken).ConfigureAwait(false);
         if (!client.Authenticated)
             await client
                 .AuthenticateAsync(_username, _password, cancellationToken)
@@ -106,7 +94,8 @@ public sealed class NntpClientPool : INntpClientPool
 
         if (!client.Connected || !client.Authenticated)
             throw new InvalidOperationException(
-                $"Failed to connect to '{_hostname}:{_port}' SSL={_useSsl} C={client.Connected} A={client.Authenticated}.'"
+                $"Failed to connect to '{_connectionOptions.Host}:{_connectionOptions.Port}' "
+                    + $"SSL={_connectionOptions.UseSsl} C={client.Connected} A={client.Authenticated}.'"
             );
 
         return client;

--- a/src/Usenet/Nntp/NntpCompression.cs
+++ b/src/Usenet/Nntp/NntpCompression.cs
@@ -1,0 +1,31 @@
+using JetBrains.Annotations;
+
+namespace Usenet.Nntp;
+
+/// <summary>
+/// The compression mode negotiated for a connection's multi-line data blocks.
+/// </summary>
+/// <remarks>
+/// Compression is configuration rather than a command: it is negotiated as part of the connection's
+/// session-setup recipe so it survives transparent pool reconnects. See
+/// <a href="https://github.com/Spottarr/Usenet/blob/main/docs/adr/0005-compressed-overview-transport-and-connection-options.md">ADR-0005</a>.
+/// Only <see cref="None"/> is honoured today; the gzip variants are reserved for a later slice.
+/// </remarks>
+[PublicAPI]
+public enum NntpCompression
+{
+    /// <summary>No compression; multi-line data blocks are transferred as plain text.</summary>
+    None = 0,
+
+    /// <summary>
+    /// <c>XFEATURE COMPRESS GZIP</c> where the compressed block is followed by a literal terminating
+    /// dot line, so the framer can find the block boundary without trusting the gzip trailer.
+    /// </summary>
+    GzipWithTerminator,
+
+    /// <summary>
+    /// <c>XFEATURE COMPRESS GZIP</c> where the compressed block is not followed by a terminating dot
+    /// line; the block ends with the stream.
+    /// </summary>
+    Gzip,
+}

--- a/src/Usenet/Nntp/NntpConnection.cs
+++ b/src/Usenet/Nntp/NntpConnection.cs
@@ -38,6 +38,7 @@ public sealed class NntpConnection : INntpConnection, INntpStreamSource
     private const int StreamDrainBudgetBytes = 64 * 1024;
 
     private readonly ILogger _log;
+    private readonly NntpConnectionOptions _options;
     private readonly TcpClient _client = new();
     private Stream? _stream;
     private PipeReader? _reader;
@@ -50,12 +51,22 @@ public sealed class NntpConnection : INntpConnection, INntpStreamSource
     /// <summary>
     /// Creates a new instance of the <see cref="NntpConnection"/> class.
     /// </summary>
+    /// <param name="options">
+    /// The transport configuration (host, port, SSL, timeouts and compression) used when connecting.
+    /// When <see langword="null"/>, a default <see cref="NntpConnectionOptions"/> is used.
+    /// </param>
     /// <param name="loggerFactory">
     /// An optional <see cref="ILoggerFactory"/> used to create the connection's logger.
     /// When <see langword="null"/>, logging is disabled via <see cref="NullLoggerFactory"/>.
     /// </param>
-    public NntpConnection(ILoggerFactory? loggerFactory = null) =>
+    public NntpConnection(
+        NntpConnectionOptions? options = null,
+        ILoggerFactory? loggerFactory = null
+    )
+    {
+        _options = options ?? new NntpConnectionOptions();
         _log = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<NntpConnection>();
+    }
 
     /// <inheritdoc/>
     public IBufferWriter<byte> Output
@@ -82,15 +93,18 @@ public sealed class NntpConnection : INntpConnection, INntpStreamSource
 
     /// <inheritdoc/>
     public async Task<TResponse> ConnectAsync<TResponse>(
-        string hostname,
-        int port,
-        bool useSsl,
         IResponseParser<TResponse> parser,
         CancellationToken cancellationToken = default
     )
     {
+        var hostname = _options.Host;
+        ArgumentException.ThrowIfNullOrWhiteSpace(hostname);
+
+        var port = _options.Port;
+        var useSsl = _options.UseSsl;
+
         _log.Connecting(hostname, port, useSsl);
-        await _client.ConnectAsync(hostname, port, cancellationToken).ConfigureAwait(false);
+        await ConnectClientAsync(hostname, port, cancellationToken).ConfigureAwait(false);
         // Disable Nagle's algorithm: now that a command is sent as a single batched flush, the
         // final sub-MSS segment would otherwise stall ~40ms against the server's delayed ACK
         // before the response can be read. NNTP is a request/response protocol that wants the
@@ -101,6 +115,38 @@ public sealed class NntpConnection : INntpConnection, INntpStreamSource
         _writer = PipeWriter.Create(_stream, new StreamPipeWriterOptions(leaveOpen: true));
         _output = new CountingBufferWriter(_writer, this);
         return await GetResponseAsync(parser, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Establishes the TCP connection, applying <see cref="NntpConnectionOptions.ConnectTimeout"/> when
+    /// it is positive. A timeout that elapses before the caller's token is cancelled surfaces as a
+    /// <see cref="TimeoutException"/>.
+    /// </summary>
+    private async Task ConnectClientAsync(
+        string hostname,
+        int port,
+        CancellationToken cancellationToken
+    )
+    {
+        var timeout = _options.ConnectTimeout;
+        if (timeout <= TimeSpan.Zero)
+        {
+            await _client.ConnectAsync(hostname, port, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(timeout);
+        try
+        {
+            await _client.ConnectAsync(hostname, port, timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"Timed out connecting to '{hostname}:{port}' after {timeout}."
+            );
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Usenet/Nntp/NntpConnectionOptions.cs
+++ b/src/Usenet/Nntp/NntpConnectionOptions.cs
@@ -1,0 +1,38 @@
+using JetBrains.Annotations;
+
+namespace Usenet.Nntp;
+
+/// <summary>
+/// Transport configuration for an <see cref="NntpConnection"/>: where to connect, whether to encrypt,
+/// how long to wait for the connection, and which compression mode to negotiate.
+/// </summary>
+/// <remarks>
+/// Consolidating connection identity into an options object lets
+/// <see cref="Usenet.Nntp.Contracts.INntpConnection.ConnectAsync{TResponse}"/> read the host, port and
+/// SSL setting from configuration instead of taking them as method arguments. See
+/// <a href="https://github.com/Spottarr/Usenet/blob/main/docs/adr/0005-compressed-overview-transport-and-connection-options.md">ADR-0005</a>.
+/// </remarks>
+[PublicAPI]
+public sealed class NntpConnectionOptions
+{
+    /// <summary>The hostname of the usenet server.</summary>
+    public string Host { get; init; } = string.Empty;
+
+    /// <summary>The port to connect on. Defaults to the standard NNTP port 119.</summary>
+    public int Port { get; init; } = 119;
+
+    /// <summary>A value indicating whether to use SSL encryption for the connection.</summary>
+    public bool UseSsl { get; init; }
+
+    /// <summary>
+    /// The maximum time to wait for the TCP connection to be established. A non-positive value
+    /// disables the timeout. Defaults to 30 seconds.
+    /// </summary>
+    public TimeSpan ConnectTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The compression mode to negotiate for multi-line data blocks. Reserved for a later slice;
+    /// <see cref="NntpCompression.None"/> is currently the only honoured value.
+    /// </summary>
+    public NntpCompression Compression { get; init; } = NntpCompression.None;
+}

--- a/src/Usenet/Nntp/NntpPoolOptions.cs
+++ b/src/Usenet/Nntp/NntpPoolOptions.cs
@@ -1,0 +1,28 @@
+using JetBrains.Annotations;
+
+namespace Usenet.Nntp;
+
+/// <summary>
+/// Configuration for an <see cref="NntpClientPool"/>: the connection options applied to every pooled
+/// client, the credentials used to authenticate them, and the maximum size of the pool.
+/// </summary>
+/// <remarks>
+/// The pool re-applies the connection options and credentials on every transparent reconnect, so they
+/// are configuration rather than per-lease arguments. See
+/// <a href="https://github.com/Spottarr/Usenet/blob/main/docs/adr/0005-compressed-overview-transport-and-connection-options.md">ADR-0005</a>.
+/// </remarks>
+[PublicAPI]
+public sealed class NntpPoolOptions
+{
+    /// <summary>The connection configuration applied to every client in the pool.</summary>
+    public required NntpConnectionOptions Connection { get; init; }
+
+    /// <summary>The username used to authenticate each pooled connection.</summary>
+    public string Username { get; init; } = string.Empty;
+
+    /// <summary>The password used to authenticate each pooled connection.</summary>
+    public string Password { get; init; } = string.Empty;
+
+    /// <summary>The maximum number of clients the pool will hold.</summary>
+    public required int MaxPoolSize { get; init; }
+}

--- a/src/Usenet/Nntp/PooledNntpClient.cs
+++ b/src/Usenet/Nntp/PooledNntpClient.cs
@@ -20,24 +20,17 @@ internal sealed class PooledNntpClient : IInternalPooledNntpClient
     public bool HasError { get; private set; }
     public bool HasPendingStream => _connection.HasPendingStream;
 
-    public PooledNntpClient(ILoggerFactory? loggerFactory = null)
+    public PooledNntpClient(NntpConnectionOptions options, ILoggerFactory? loggerFactory = null)
     {
-        _connection = new NntpConnection(loggerFactory);
+        _connection = new NntpConnection(options, loggerFactory);
         _client = new NntpClient(_connection, loggerFactory);
     }
 
     #region INntpClient
 
-    public async Task<bool> ConnectAsync(
-        string hostname,
-        int port,
-        bool useSsl,
-        CancellationToken cancellationToken = default
-    )
+    public async Task<bool> ConnectAsync(CancellationToken cancellationToken = default)
     {
-        var res = await _client
-            .ConnectAsync(hostname, port, useSsl, cancellationToken)
-            .ConfigureAwait(false);
+        var res = await _client.ConnectAsync(cancellationToken).ConfigureAwait(false);
         NntpConnected = res;
         return res;
     }

--- a/src/Usenet/PublicAPI.Unshipped.txt
+++ b/src/Usenet/PublicAPI.Unshipped.txt
@@ -77,8 +77,34 @@ Usenet.Nntp.NntpConnection.BufferLine(string! line) -> void
 Usenet.DependencyInjection.UsenetServiceCollectionExtensions
 Usenet.Nntp.Builders.NntpArticleBuilder.NntpArticleBuilder(Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null) -> void
 Usenet.Nntp.NntpClient.NntpClient(Usenet.Nntp.Contracts.INntpConnection! connection, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null) -> void
-Usenet.Nntp.NntpClientPool.NntpClientPool(int maxPoolSize, string! hostname, int port, bool useSsl, string! username, string! password, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null) -> void
-Usenet.Nntp.NntpConnection.NntpConnection(Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null) -> void
+Usenet.Nntp.NntpClientPool.NntpClientPool(Usenet.Nntp.NntpPoolOptions! options, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null) -> void
+Usenet.Nntp.NntpConnection.NntpConnection(Usenet.Nntp.NntpConnectionOptions? options = null, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null) -> void
+Usenet.Nntp.NntpCompression
+Usenet.Nntp.NntpCompression.None = 0 -> Usenet.Nntp.NntpCompression
+Usenet.Nntp.NntpCompression.GzipWithTerminator = 1 -> Usenet.Nntp.NntpCompression
+Usenet.Nntp.NntpCompression.Gzip = 2 -> Usenet.Nntp.NntpCompression
+Usenet.Nntp.NntpConnectionOptions
+Usenet.Nntp.NntpConnectionOptions.NntpConnectionOptions() -> void
+Usenet.Nntp.NntpConnectionOptions.Host.get -> string!
+Usenet.Nntp.NntpConnectionOptions.Host.init -> void
+Usenet.Nntp.NntpConnectionOptions.Port.get -> int
+Usenet.Nntp.NntpConnectionOptions.Port.init -> void
+Usenet.Nntp.NntpConnectionOptions.UseSsl.get -> bool
+Usenet.Nntp.NntpConnectionOptions.UseSsl.init -> void
+Usenet.Nntp.NntpConnectionOptions.ConnectTimeout.get -> System.TimeSpan
+Usenet.Nntp.NntpConnectionOptions.ConnectTimeout.init -> void
+Usenet.Nntp.NntpConnectionOptions.Compression.get -> Usenet.Nntp.NntpCompression
+Usenet.Nntp.NntpConnectionOptions.Compression.init -> void
+Usenet.Nntp.NntpPoolOptions
+Usenet.Nntp.NntpPoolOptions.NntpPoolOptions() -> void
+Usenet.Nntp.NntpPoolOptions.Connection.get -> Usenet.Nntp.NntpConnectionOptions!
+Usenet.Nntp.NntpPoolOptions.Connection.init -> void
+Usenet.Nntp.NntpPoolOptions.Username.get -> string!
+Usenet.Nntp.NntpPoolOptions.Username.init -> void
+Usenet.Nntp.NntpPoolOptions.Password.get -> string!
+Usenet.Nntp.NntpPoolOptions.Password.init -> void
+Usenet.Nntp.NntpPoolOptions.MaxPoolSize.get -> int
+Usenet.Nntp.NntpPoolOptions.MaxPoolSize.init -> void
 static Usenet.DependencyInjection.UsenetServiceCollectionExtensions.AddUsenet(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 *REMOVED*static Usenet.Logger.Create<T>() -> Microsoft.Extensions.Logging.ILogger!
 *REMOVED*static Usenet.Logger.Factory.get -> Microsoft.Extensions.Logging.ILoggerFactory!
@@ -168,7 +194,7 @@ Usenet.Nntp.Contracts.INntpClientCompression.XfeatureCompressGzipAsync(bool with
 Usenet.Nntp.Contracts.INntpClientCompression.XzhdrAsync(string! field, Usenet.Nntp.Models.NntpArticleRange! range, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Responses.NntpStreamResponse<Usenet.Nntp.Models.NntpHeaderField!>!>!
 Usenet.Nntp.Contracts.INntpClientCompression.XzhdrByMessageIdAsync(string! field, Usenet.Nntp.Models.NntpMessageId! messageId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Models.NntpHeaderField?>!
 Usenet.Nntp.Contracts.INntpClientCompression.XzverAsync(Usenet.Nntp.Models.NntpArticleRange! range, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Responses.NntpStreamResponse<Usenet.Nntp.Models.NntpArticleOverview!>!>!
-Usenet.Nntp.Contracts.INntpClientConnection.ConnectAsync(string! hostname, int port, bool useSsl, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
+Usenet.Nntp.Contracts.INntpClientConnection.ConnectAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 Usenet.Nntp.Contracts.INntpClientConnection.QuitAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Responses.NntpResponse!>!
 Usenet.Nntp.Contracts.INntpClientPool.GetLease(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Contracts.IPooledNntpClientLease!>!
 Usenet.Nntp.Contracts.INntpClientRfc2980.CurrentXhdrAsync(string! field, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Responses.NntpStreamResponse<Usenet.Nntp.Models.NntpHeaderField!>!>!
@@ -222,7 +248,7 @@ Usenet.Nntp.Contracts.INntpClientRfc6048.ListMotdAsync(System.Threading.Cancella
 Usenet.Nntp.Contracts.INntpClientRfc6048.ListSubscriptionsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Models.NntpGroups!>!
 Usenet.Nntp.Contracts.INntpConnection.BufferedMultiLineCommandAsync<TResponse>(string! command, Usenet.Nntp.Parsers.IBufferedMultiLineResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
 Usenet.Nntp.Contracts.INntpConnection.CommandAsync<TResponse>(string! command, Usenet.Nntp.Parsers.IResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
-Usenet.Nntp.Contracts.INntpConnection.ConnectAsync<TResponse>(string! hostname, int port, bool useSsl, Usenet.Nntp.Parsers.IResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Usenet.Nntp.Contracts.INntpConnection.ConnectAsync<TResponse>(Usenet.Nntp.Parsers.IResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
 Usenet.Nntp.Contracts.INntpConnection.FlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Usenet.Nntp.Contracts.INntpConnection.GetResponseAsync<TResponse>(Usenet.Nntp.Parsers.IResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
 Usenet.Nntp.Contracts.INntpConnection.MultiLineCommandAsync<TResponse>(string! command, Usenet.Nntp.Parsers.IMultiLineResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
@@ -234,7 +260,7 @@ Usenet.Nntp.NntpClient.AuthenticateAsync(string! username, string! password, Sys
 Usenet.Nntp.NntpClient.BodyAsync(Usenet.Nntp.Models.NntpMessageId! messageId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Responses.NntpArticleResponse!>!
 Usenet.Nntp.NntpClient.BodyByNumberAsync(long number, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Responses.NntpArticleResponse!>!
 Usenet.Nntp.NntpClient.CapabilitiesAsync(string? keyword = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Models.NntpCapabilities!>!
-Usenet.Nntp.NntpClient.ConnectAsync(string! hostname, int port, bool useSsl, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
+Usenet.Nntp.NntpClient.ConnectAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 Usenet.Nntp.NntpClient.CurrentArticleAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Responses.NntpArticleResponse!>!
 Usenet.Nntp.NntpClient.CurrentBodyAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Responses.NntpArticleResponse!>!
 Usenet.Nntp.NntpClient.CurrentHdrAsync(string! field, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Responses.NntpStreamResponse<Usenet.Nntp.Models.NntpHeaderField!>!>!
@@ -288,7 +314,7 @@ Usenet.Nntp.NntpClient.XzverAsync(Usenet.Nntp.Models.NntpArticleRange! range, Sy
 Usenet.Nntp.NntpClientPool.GetLease(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Usenet.Nntp.Contracts.IPooledNntpClientLease!>!
 Usenet.Nntp.NntpConnection.BufferedMultiLineCommandAsync<TResponse>(string! command, Usenet.Nntp.Parsers.IBufferedMultiLineResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
 Usenet.Nntp.NntpConnection.CommandAsync<TResponse>(string! command, Usenet.Nntp.Parsers.IResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
-Usenet.Nntp.NntpConnection.ConnectAsync<TResponse>(string! hostname, int port, bool useSsl, Usenet.Nntp.Parsers.IResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Usenet.Nntp.NntpConnection.ConnectAsync<TResponse>(Usenet.Nntp.Parsers.IResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
 Usenet.Nntp.NntpConnection.FlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Usenet.Nntp.NntpConnection.GetResponseAsync<TResponse>(Usenet.Nntp.Parsers.IResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
 Usenet.Nntp.NntpConnection.MultiLineCommandAsync<TResponse>(string! command, Usenet.Nntp.Parsers.IMultiLineResponseParser<TResponse>! parser, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!

--- a/tests/Usenet.Benchmarks/Nntp/Client/NntpBenchmarks.cs
+++ b/tests/Usenet.Benchmarks/Nntp/Client/NntpBenchmarks.cs
@@ -25,9 +25,11 @@ public class NntpBenchmarks
     public async Task Setup()
     {
         _server = new BenchmarkNntpServer();
-        _connection = new NntpConnection();
+        _connection = new NntpConnection(
+            new NntpConnectionOptions { Host = "127.0.0.1", Port = _server.Port }
+        );
         _client = new NntpClient(_connection);
-        await _client.ConnectAsync("127.0.0.1", _server.Port, false);
+        await _client.ConnectAsync();
     }
 
     [GlobalCleanup]

--- a/tests/Usenet.Benchmarks/Nntp/Client/PostBenchmarks.cs
+++ b/tests/Usenet.Benchmarks/Nntp/Client/PostBenchmarks.cs
@@ -29,9 +29,11 @@ public class PostBenchmarks
     public async Task Setup()
     {
         _server = new BenchmarkNntpServer();
-        _connection = new NntpConnection();
+        _connection = new NntpConnection(
+            new NntpConnectionOptions { Host = "127.0.0.1", Port = _server.Port }
+        );
         _client = new NntpClient(_connection);
-        await _client.ConnectAsync("127.0.0.1", _server.Port, false);
+        await _client.ConnectAsync();
 
         var builder = new NntpArticleBuilder()
             .SetMessageId("benchmark@example.com")

--- a/tests/Usenet.Tests/DependencyInjection/UsenetLoggingTests.cs
+++ b/tests/Usenet.Tests/DependencyInjection/UsenetLoggingTests.cs
@@ -17,7 +17,15 @@ internal sealed class UsenetLoggingTests
         using var connection = new NntpConnection();
         var client = new NntpClient(connection);
         var builder = new NntpArticleBuilder();
-        using var pool = new NntpClientPool(1, "example.server", 119, false, "user", "pass");
+        using var pool = new NntpClientPool(
+            new NntpPoolOptions
+            {
+                MaxPoolSize = 1,
+                Username = "user",
+                Password = "pass",
+                Connection = new NntpConnectionOptions { Host = "example.server" },
+            }
+        );
 
         await Assert.That(client).IsNotNull();
         await Assert.That(builder).IsNotNull();

--- a/tests/Usenet.Tests/Nntp/NntpClientPostTests.cs
+++ b/tests/Usenet.Tests/Nntp/NntpClientPostTests.cs
@@ -9,19 +9,17 @@ namespace Usenet.Tests.Nntp;
 
 internal sealed class NntpClientPostTests
 {
+    private static NntpConnectionOptions LoopbackOptions(int port) =>
+        new() { Host = IPAddress.Loopback.ToString(), Port = port };
+
     [Test]
     public async Task PostShouldRoundTripArticle(CancellationToken cancellationToken)
     {
         using var server = new TestNntpServer();
-        using var connection = new NntpConnection();
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
         var client = new NntpClient(connection);
 
-        await client.ConnectAsync(
-            IPAddress.Loopback.ToString(),
-            server.Port,
-            false,
-            cancellationToken
-        );
+        await client.ConnectAsync(cancellationToken);
 
         var article = new NntpArticleBuilder()
             .SetMessageId("1@example.com")
@@ -47,15 +45,10 @@ internal sealed class NntpClientPostTests
     public async Task IhaveShouldRoundTripArticle(CancellationToken cancellationToken)
     {
         using var server = new TestNntpServer();
-        using var connection = new NntpConnection();
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
         var client = new NntpClient(connection);
 
-        await client.ConnectAsync(
-            IPAddress.Loopback.ToString(),
-            server.Port,
-            false,
-            cancellationToken
-        );
+        await client.ConnectAsync(cancellationToken);
 
         var article = new NntpArticleBuilder()
             .SetMessageId("2@example.com")
@@ -76,15 +69,9 @@ internal sealed class NntpClientPostTests
     public async Task PostShouldStreamYencBodyThroughOutputSink(CancellationToken cancellationToken)
     {
         using var server = new TestNntpServer();
-        using var connection = new NntpConnection();
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
 
-        await connection.ConnectAsync(
-            IPAddress.Loopback.ToString(),
-            server.Port,
-            false,
-            new ResponseParser(200),
-            cancellationToken
-        );
+        await connection.ConnectAsync(new ResponseParser(200), cancellationToken);
 
         var initial = await connection.CommandAsync(
             "POST",

--- a/tests/Usenet.Tests/Nntp/NntpClientStreamingTests.cs
+++ b/tests/Usenet.Tests/Nntp/NntpClientStreamingTests.cs
@@ -7,19 +7,16 @@ namespace Usenet.Tests.Nntp;
 
 internal sealed class NntpClientStreamingTests
 {
+    private static NntpConnectionOptions LoopbackOptions(int port) =>
+        new() { Host = IPAddress.Loopback.ToString(), Port = port };
+
     private static async Task<NntpClient> ConnectAsync(
         NntpConnection connection,
-        StreamingNntpServer server,
         CancellationToken cancellationToken
     )
     {
         var client = new NntpClient(connection);
-        await client.ConnectAsync(
-            IPAddress.Loopback.ToString(),
-            server.Port,
-            false,
-            cancellationToken
-        );
+        await client.ConnectAsync(cancellationToken);
         return client;
     }
 
@@ -27,8 +24,8 @@ internal sealed class NntpClientStreamingTests
     public async Task ShouldStreamXoverRangePerLine(CancellationToken cancellationToken)
     {
         await using var server = new StreamingNntpServer();
-        using var connection = new NntpConnection();
-        var client = await ConnectAsync(connection, server, cancellationToken);
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
+        var client = await ConnectAsync(connection, cancellationToken);
 
         await using var response = await client.XoverAsync(
             NntpArticleRange.Range(1, 5),
@@ -53,8 +50,8 @@ internal sealed class NntpClientStreamingTests
     public async Task ShouldStreamOverRangePerLine(CancellationToken cancellationToken)
     {
         await using var server = new StreamingNntpServer();
-        using var connection = new NntpConnection();
-        var client = await ConnectAsync(connection, server, cancellationToken);
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
+        var client = await ConnectAsync(connection, cancellationToken);
 
         await using var response = await client.OverAsync(
             NntpArticleRange.Range(1, 5),
@@ -81,8 +78,8 @@ internal sealed class NntpClientStreamingTests
     public async Task ShouldReturnSingleOverviewByMessageId(CancellationToken cancellationToken)
     {
         await using var server = new StreamingNntpServer();
-        using var connection = new NntpConnection();
-        var client = await ConnectAsync(connection, server, cancellationToken);
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
+        var client = await ConnectAsync(connection, cancellationToken);
 
         var overview = await client.OverByMessageIdAsync(
             new NntpMessageId("42@example.com"),
@@ -103,8 +100,8 @@ internal sealed class NntpClientStreamingTests
     public async Task ShouldReturnNullOverviewWhenArticleAbsent(CancellationToken cancellationToken)
     {
         await using var server = new StreamingNntpServer();
-        using var connection = new NntpConnection();
-        var client = await ConnectAsync(connection, server, cancellationToken);
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
+        var client = await ConnectAsync(connection, cancellationToken);
 
         var overview = await client.OverByMessageIdAsync(
             new NntpMessageId(StreamingNntpServer.MissingMessageId),
@@ -118,8 +115,8 @@ internal sealed class NntpClientStreamingTests
     public async Task ShouldReturnSingleHeaderFieldByMessageId(CancellationToken cancellationToken)
     {
         await using var server = new StreamingNntpServer();
-        using var connection = new NntpConnection();
-        var client = await ConnectAsync(connection, server, cancellationToken);
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
+        var client = await ConnectAsync(connection, cancellationToken);
 
         var header = await client.HdrByMessageIdAsync(
             "Subject",
@@ -138,8 +135,8 @@ internal sealed class NntpClientStreamingTests
     )
     {
         await using var server = new StreamingNntpServer();
-        using var connection = new NntpConnection();
-        var client = await ConnectAsync(connection, server, cancellationToken);
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
+        var client = await ConnectAsync(connection, cancellationToken);
 
         var header = await client.XhdrByMessageIdAsync(
             "Subject",
@@ -157,8 +154,8 @@ internal sealed class NntpClientStreamingTests
     )
     {
         await using var server = new StreamingNntpServer();
-        using var connection = new NntpConnection();
-        var client = await ConnectAsync(connection, server, cancellationToken);
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
+        var client = await ConnectAsync(connection, cancellationToken);
 
         var header = await client.HdrByMessageIdAsync(
             "Subject",
@@ -173,8 +170,8 @@ internal sealed class NntpClientStreamingTests
     public async Task ShouldStreamListGroupArticleNumbers(CancellationToken cancellationToken)
     {
         await using var server = new StreamingNntpServer();
-        using var connection = new NntpConnection();
-        var client = await ConnectAsync(connection, server, cancellationToken);
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
+        var client = await ConnectAsync(connection, cancellationToken);
 
         await using var response = await client.ListGroupAsync(
             "misc.test",
@@ -194,8 +191,8 @@ internal sealed class NntpClientStreamingTests
     public async Task ShouldStreamListActiveGroups(CancellationToken cancellationToken)
     {
         await using var server = new StreamingNntpServer();
-        using var connection = new NntpConnection();
-        var client = await ConnectAsync(connection, server, cancellationToken);
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
+        var client = await ConnectAsync(connection, cancellationToken);
 
         await using var response = await client.ListActiveAsync(
             cancellationToken: cancellationToken
@@ -217,8 +214,8 @@ internal sealed class NntpClientStreamingTests
     public async Task ShouldReuseConnectionAfterEarlyDisposal(CancellationToken cancellationToken)
     {
         await using var server = new StreamingNntpServer();
-        using var connection = new NntpConnection();
-        var client = await ConnectAsync(connection, server, cancellationToken);
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
+        var client = await ConnectAsync(connection, cancellationToken);
 
         // Consume a single row then dispose the response without enumerating the rest.
         await using (
@@ -245,8 +242,8 @@ internal sealed class NntpClientStreamingTests
     )
     {
         await using var server = new StreamingNntpServer();
-        using var connection = new NntpConnection();
-        var client = await ConnectAsync(connection, server, cancellationToken);
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
+        var client = await ConnectAsync(connection, cancellationToken);
 
         // Start a stream but do not enumerate or dispose it, leaving the data block on the wire.
         _ = await client.XoverAsync(NntpArticleRange.Range(1, 100), cancellationToken);
@@ -259,8 +256,8 @@ internal sealed class NntpClientStreamingTests
     public async Task ShouldKeepMemoryFlatOverLargeXoverRange(CancellationToken cancellationToken)
     {
         await using var server = new StreamingNntpServer();
-        using var connection = new NntpConnection();
-        var client = await ConnectAsync(connection, server, cancellationToken);
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
+        var client = await ConnectAsync(connection, cancellationToken);
 
         const int count = 200_000;
 

--- a/tests/Usenet.Tests/Nntp/NntpConnectionTests.cs
+++ b/tests/Usenet.Tests/Nntp/NntpConnectionTests.cs
@@ -16,19 +16,41 @@ internal sealed class NntpConnectionTests
         "last body line",
     ];
 
+    private static NntpConnectionOptions LoopbackOptions(int port) =>
+        new() { Host = IPAddress.Loopback.ToString(), Port = port };
+
+    [Test]
+    public async Task ShouldDefaultConnectionOptions()
+    {
+        var options = new NntpConnectionOptions();
+
+        await Assert.That(options.Host).IsEqualTo(string.Empty);
+        await Assert.That(options.Port).IsEqualTo(119);
+        await Assert.That(options.UseSsl).IsFalse();
+        await Assert.That(options.ConnectTimeout).IsEqualTo(TimeSpan.FromSeconds(30));
+        await Assert.That(options.Compression).IsEqualTo(NntpCompression.None);
+    }
+
+    [Test]
+    public async Task ShouldThrowWhenConnectingWithoutHost(CancellationToken cancellationToken)
+    {
+        // The host is read from the options; a connection with no host configured cannot connect.
+        using var connection = new NntpConnection();
+
+        await Assert
+            .That(async () =>
+                await connection.ConnectAsync(new ResponseParser(200), cancellationToken)
+            )
+            .ThrowsExactly<ArgumentException>();
+    }
+
     [Test]
     public async Task ShouldFrameSingleLineResponse(CancellationToken cancellationToken)
     {
         await using var server = new ScriptedNntpServer();
-        using var connection = new NntpConnection();
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
 
-        var response = await connection.ConnectAsync(
-            IPAddress.Loopback.ToString(),
-            server.Port,
-            false,
-            new ResponseParser(200),
-            cancellationToken
-        );
+        var response = await connection.ConnectAsync(new ResponseParser(200), cancellationToken);
 
         await Assert.That(response.Code).IsEqualTo(200);
         await Assert.That(response.Message).IsEqualTo("Scripted server ready");
@@ -40,15 +62,9 @@ internal sealed class NntpConnectionTests
     )
     {
         await using var server = new ScriptedNntpServer();
-        using var connection = new NntpConnection();
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
 
-        await connection.ConnectAsync(
-            IPAddress.Loopback.ToString(),
-            server.Port,
-            false,
-            new ResponseParser(200),
-            cancellationToken
-        );
+        await connection.ConnectAsync(new ResponseParser(200), cancellationToken);
 
         var lines = await connection.MultiLineCommandAsync(
             "ARTICLE 1",
@@ -67,15 +83,9 @@ internal sealed class NntpConnectionTests
     )
     {
         await using var server = new ScriptedNntpServer();
-        using var connection = new NntpConnection();
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
 
-        await connection.ConnectAsync(
-            IPAddress.Loopback.ToString(),
-            server.Port,
-            false,
-            new ResponseParser(200),
-            cancellationToken
-        );
+        await connection.ConnectAsync(new ResponseParser(200), cancellationToken);
 
         using var response = await connection.BufferedMultiLineCommandAsync(
             "ARTICLE 1",
@@ -92,15 +102,9 @@ internal sealed class NntpConnectionTests
     public async Task ShouldCountBytesReadAndWritten(CancellationToken cancellationToken)
     {
         await using var server = new ScriptedNntpServer();
-        using var connection = new NntpConnection();
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
 
-        await connection.ConnectAsync(
-            IPAddress.Loopback.ToString(),
-            server.Port,
-            false,
-            new ResponseParser(200),
-            cancellationToken
-        );
+        await connection.ConnectAsync(new ResponseParser(200), cancellationToken);
 
         await connection.MultiLineCommandAsync(
             "ARTICLE 1",
@@ -121,15 +125,9 @@ internal sealed class NntpConnectionTests
     public async Task ShouldStreamMultiLineBlockPerLine(CancellationToken cancellationToken)
     {
         await using var server = new ScriptedNntpServer();
-        using var connection = new NntpConnection();
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
 
-        await connection.ConnectAsync(
-            IPAddress.Loopback.ToString(),
-            server.Port,
-            false,
-            new ResponseParser(200),
-            cancellationToken
-        );
+        await connection.ConnectAsync(new ResponseParser(200), cancellationToken);
 
         await using var response = await connection.MultiLineStreamCommandAsync<string>(
             "XOVER 1-3",
@@ -156,15 +154,9 @@ internal sealed class NntpConnectionTests
     )
     {
         await using var server = new ScriptedNntpServer();
-        using var connection = new NntpConnection();
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
 
-        await connection.ConnectAsync(
-            IPAddress.Loopback.ToString(),
-            server.Port,
-            false,
-            new ResponseParser(200),
-            cancellationToken
-        );
+        await connection.ConnectAsync(new ResponseParser(200), cancellationToken);
 
         // Consume only the first line, then dispose without enumerating the rest.
         await using (

--- a/tests/Usenet.Tests/Nntp/Pooling/NntpClientPoolTests.cs
+++ b/tests/Usenet.Tests/Nntp/Pooling/NntpClientPoolTests.cs
@@ -15,7 +15,20 @@ internal sealed class NntpClientPoolTests
     {
         await Assert
             .That(() =>
-                new NntpClientPool(maxPoolSize, string.Empty, 0, true, string.Empty, string.Empty)
+                new NntpClientPool(
+                    new NntpPoolOptions
+                    {
+                        MaxPoolSize = maxPoolSize,
+                        Username = string.Empty,
+                        Password = string.Empty,
+                        Connection = new NntpConnectionOptions
+                        {
+                            Host = string.Empty,
+                            Port = 0,
+                            UseSsl = true,
+                        },
+                    }
+                )
             )
             .ThrowsExactly<ArgumentOutOfRangeException>();
     }
@@ -25,12 +38,18 @@ internal sealed class NntpClientPoolTests
     public async Task AllClientsBorrowed(CancellationToken cancellationToken)
     {
         using var pool = new NntpClientPool(
-            1,
-            "example.server",
-            563,
-            true,
-            "example.user",
-            "example.pass"
+            new NntpPoolOptions
+            {
+                MaxPoolSize = 1,
+                Username = "example.user",
+                Password = "example.pass",
+                Connection = new NntpConnectionOptions
+                {
+                    Host = "example.server",
+                    Port = 563,
+                    UseSsl = true,
+                },
+            }
         )
         {
             WaitTimeout = TimeSpan.Zero,
@@ -50,12 +69,18 @@ internal sealed class NntpClientPoolTests
     public async Task ClientAvailable(CancellationToken cancellationToken)
     {
         using var pool = new NntpClientPool(
-            1,
-            "example.server",
-            563,
-            true,
-            "example.user",
-            "example.pass"
+            new NntpPoolOptions
+            {
+                MaxPoolSize = 1,
+                Username = "example.user",
+                Password = "example.pass",
+                Connection = new NntpConnectionOptions
+                {
+                    Host = "example.server",
+                    Port = 563,
+                    UseSsl = true,
+                },
+            }
         )
         {
             WaitTimeout = TimeSpan.Zero,
@@ -77,12 +102,18 @@ internal sealed class NntpClientPoolTests
     {
         using var server = new TestNntpServer();
         using var pool = new NntpClientPool(
-            1,
-            "127.0.0.1",
-            server.Port,
-            false,
-            "example.user",
-            "example.pass"
+            new NntpPoolOptions
+            {
+                MaxPoolSize = 1,
+                Username = "example.user",
+                Password = "example.pass",
+                Connection = new NntpConnectionOptions
+                {
+                    Host = "127.0.0.1",
+                    Port = server.Port,
+                    UseSsl = false,
+                },
+            }
         )
         {
             WaitTimeout = TimeSpan.Zero,
@@ -125,12 +156,18 @@ internal sealed class NntpClientPoolTests
         const int maxPoolSize = 4;
 
         using var pool = new NntpClientPool(
-            maxPoolSize,
-            "example.server",
-            563,
-            true,
-            "example.user",
-            "example.pass"
+            new NntpPoolOptions
+            {
+                MaxPoolSize = maxPoolSize,
+                Username = "example.user",
+                Password = "example.pass",
+                Connection = new NntpConnectionOptions
+                {
+                    Host = "example.server",
+                    Port = 563,
+                    UseSsl = true,
+                },
+            }
         )
         {
             // Keep the idle monitor out of the way so it does not race the borrow/return storm.
@@ -161,12 +198,18 @@ internal sealed class NntpClientPoolTests
     {
         await using var server = new StreamingNntpServer();
         using var pool = new NntpClientPool(
-            1,
-            "127.0.0.1",
-            server.Port,
-            false,
-            "example.user",
-            "example.pass"
+            new NntpPoolOptions
+            {
+                MaxPoolSize = 1,
+                Username = "example.user",
+                Password = "example.pass",
+                Connection = new NntpConnectionOptions
+                {
+                    Host = "127.0.0.1",
+                    Port = server.Port,
+                    UseSsl = false,
+                },
+            }
         )
         {
             WaitTimeout = TimeSpan.Zero,
@@ -212,12 +255,18 @@ internal sealed class NntpClientPoolTests
     {
         await using var server = new StreamingNntpServer();
         using var pool = new NntpClientPool(
-            1,
-            "127.0.0.1",
-            server.Port,
-            false,
-            "example.user",
-            "example.pass"
+            new NntpPoolOptions
+            {
+                MaxPoolSize = 1,
+                Username = "example.user",
+                Password = "example.pass",
+                Connection = new NntpConnectionOptions
+                {
+                    Host = "127.0.0.1",
+                    Port = server.Port,
+                    UseSsl = false,
+                },
+            }
         )
         {
             WaitTimeout = TimeSpan.Zero,

--- a/tests/Usenet.Tests/Nntp/Writers/ArticleWriterTests.cs
+++ b/tests/Usenet.Tests/Nntp/Writers/ArticleWriterTests.cs
@@ -131,17 +131,10 @@ internal sealed class MockConnection : INntpConnection
 
     public void Dispose() { }
 
-    public Task<TResponse> ConnectAsync<TResponse>(
-        string hostname,
-        int port,
-        bool useSsl,
-        IResponseParser<TResponse> parser
-    ) => throw new NotImplementedException();
+    public Task<TResponse> ConnectAsync<TResponse>(IResponseParser<TResponse> parser) =>
+        throw new NotImplementedException();
 
     public Task<TResponse> ConnectAsync<TResponse>(
-        string hostname,
-        int port,
-        bool useSsl,
         IResponseParser<TResponse> parser,
         CancellationToken cancellationToken
     ) => throw new NotImplementedException();

--- a/tests/Usenet.Tests/Nntp/XoverAllocationTests.cs
+++ b/tests/Usenet.Tests/Nntp/XoverAllocationTests.cs
@@ -27,21 +27,18 @@ internal sealed class XoverAllocationTests
     // runtime variation but trips if the per-row cost grows (e.g. extra copies or boxing).
     private const long MaxBytesPerRow = 896;
 
+    private static NntpConnectionOptions LoopbackOptions(int port) =>
+        new() { Host = IPAddress.Loopback.ToString(), Port = port };
+
     [Test]
     internal async Task StreamedOverviewRowShouldStayUnderAllocationCeiling(
         CancellationToken cancellationToken
     )
     {
         await using var server = new OverviewNntpServer();
-        using var connection = new NntpConnection();
+        using var connection = new NntpConnection(LoopbackOptions(server.Port));
 
-        await connection.ConnectAsync(
-            IPAddress.Loopback.ToString(),
-            server.Port,
-            false,
-            new ResponseParser(200),
-            cancellationToken
-        );
+        await connection.ConnectAsync(new ResponseParser(200), cancellationToken);
 
         // Warm up both ranges so cached server buffers and JIT costs stay out of the window.
         await ReadOverviewAsync(connection, SmallRange, cancellationToken);


### PR DESCRIPTION
Implements part 1 of [ADR-0005](docs/adr/0005-compressed-overview-transport-and-connection-options.md). Closes #141.

Connection setup was scattered: `NntpConnection` took only a logger, `ConnectAsync` took host/port/SSL as method arguments, and `NntpClientPool` took them positionally in a 6-arg constructor. This consolidates that into options objects.

## Changes

- **`NntpConnectionOptions`** — `Host`, `Port`, `UseSsl`, `ConnectTimeout`, and a stubbed `Compression` knob (`NntpCompression` enum, `None` default).
- **`NntpPoolOptions`** — the connection options plus `Username`, `Password` and `MaxPoolSize`.
- `new NntpConnection(NntpConnectionOptions?)` and `new NntpClientPool(NntpPoolOptions)`; the 6-arg positional pool constructor is removed.
- `ConnectAsync(CancellationToken cancellationToken = default)` reads host/port/SSL from the options (single method, consistent with ADR-0004); no host/port/ssl parameters remain on it.
- `ConnectTimeout` is wired into the TCP connect and surfaces as a `TimeoutException` when it elapses.
- `AddUsenet` resolves an optional `NntpConnectionOptions` from the container, falling back to defaults, so DI registration still works.

Compression itself is **not** implemented here — that is the next slice. `NntpCompression.None` is the only honoured value.

## Acceptance criteria

- [x] `NntpConnectionOptions` and `NntpPoolOptions` exist and carry the transport/credential/pool configuration
- [x] Connection and pool are constructed from the options objects; the old positional pool constructor is removed
- [x] `ConnectAsync(ct = default)` reads connection identity from the options
- [x] DI registration (`AddUsenet`) and defaults still work
- [x] Public API baseline regenerated; CSharpier applied; tests updated to construct via options and passing
- [x] Affected README examples updated